### PR TITLE
Fix: ExcelColumn 어노테이션이 하나도 없을 경우 오류 발생하게 변경

### DIFF
--- a/src/test/java/io/github/hee9841/excel/meta/ColumnInfoMapperTest.java
+++ b/src/test/java/io/github/hee9841/excel/meta/ColumnInfoMapperTest.java
@@ -55,6 +55,28 @@ class ColumnInfoMapperTest {
         assertTrue(exceptionMsg.contains(expectedMsg));
     }
 
+    @DisplayName("@ExcelColumn 어노테이션이 하나라도 없으면 예외를 발생한다.")
+    @Test
+    void noExcelColumnAnnotation_throwException() {
+        //given
+        @Excel
+        class TestDto {
+            String id;
+        }
+
+        String expectedMsg = "No @ExcelColumn annotations found in class";
+
+        ColumnInfoMapper columnInfoMapper = ColumnInfoMapper.of(
+            TestDto.class, wb);
+
+        //when
+        String exceptionMsg = assertThrows(
+            ExcelException.class,
+            columnInfoMapper::map).getMessage();
+
+        assertTrue(exceptionMsg.contains(expectedMsg));
+    }
+
     @Nested
     class ColumnIndexMappingTest {
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- ExcelColumn 어노테이션이 하나도 없을 경우 오류 발생하게 변경한다.
