### PR TITLE
Chore: Maven Publishing를 위한 gradle 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ group = 'io.github.hee9841.excel'
 version = '1.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,23 @@
+import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     id 'java'
+    id "com.vanniktech.maven.publish" version "0.28.0"
+    id 'signing'
 }
 
 group = 'io.github.hee9841.excel'
-version = '1.0-SNAPSHOT'
+version = '0.0.0'
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(11))
 }
+
+compileJava {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}
+
+
 
 repositories {
     mavenCentral()
@@ -43,5 +53,46 @@ test {
 javadoc {
     options {
         encoding = 'UTF-8'
+    }
+}
+
+
+signing {
+    sign publishing.publications
+}
+
+mavenPublishing {
+    signAllPublications()
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    coordinates("io.github.hee9841", "excel-module", version)
+
+    pom {
+        name = "excel-module"
+        description = "A Java library that helps you work with Excel files easily."
+        inceptionYear = "2025"
+        url = "https://github.com/hee9841/excel-module"
+
+        licenses {
+            license {
+                name = 'Apache License 2.0'
+                url = 'https://github.com/hee9841/excel-module/blob/dev/LICENSE'
+            }
+        }
+
+        developers {
+            developer {
+                id = 'hee9841'
+                name = 'SungHee Lee'
+                email = 'lee98417716@gmail.com'
+            }
+
+        }
+
+        scm {
+            connection = 'scm:git:git://github.com/hee9841/excel-module.git'
+            developerConnection = 'scm:git:ssh://github.com:hee9841/excel-module.git'
+            url = 'https://github.com/hee9841/excel-module/tree/master'
+        }
     }
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- Maven Publishing를 위해 gradle 설정을 추가합니다.
    -  com.vanniktech.maven.publish, signing 플러그인 추가
    - mavenPublishing 작성
- com.vanniktech.maven.publish플러그인 사용을 위해 자바버전을 8에서 11로 변경합니다.