### PR TITLE
Docs: javadocs 관련 의존성 추가 및 배포된 maven repository url 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Excel Module
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.hee9841.excel/excel-module.svg)](https://search.maven.org/artifact/io.github.hee9841.excel/excel-module)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.hee9841/excel-module.svg)](https://search.maven.org/artifact/io.github.hee9841/excel-module)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://github.com/hee9841/excel-module/workflows/Java%20CI%20with%20Gradle/badge.svg)](https://github.com/hee9841/excel-module/actions)
 [![Coverage Status](https://coveralls.io/repos/github/hee9841/excel-module/badge.svg?branch=main)](https://coveralls.io/github/hee9841/excel-module?branch=main)

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'java'
     id "com.vanniktech.maven.publish" version "0.28.0"
@@ -12,6 +15,15 @@ version = '0.0.0'
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+    withSourcesJar() // 소스 코드도 포함
+}
+
+javadoc {
+    options {
+        encoding = 'UTF-8'
+        charSet = 'UTF-8'
+        links 'https://docs.oracle.com/en/java/javase/11/docs/api/'
+    }
 }
 
 compileJava {
@@ -51,12 +63,6 @@ test {
     useJUnitPlatform()
 }
 
-javadoc {
-    options {
-        encoding = 'UTF-8'
-    }
-}
-
 
 signing {
     useInMemoryPgpKeys(
@@ -68,6 +74,7 @@ signing {
 }
 
 mavenPublishing {
+    configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
     signAllPublications()
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
@@ -117,4 +124,3 @@ tasks.jacocoTestReport {
 tasks.coveralls {
     dependsOn tasks.jacocoTestReport // 테스트 리포트가 먼저 실행되도록 설정
 }
-


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- maven 배포 시  javadocs 배포 가능하게 의존성을 추가합니다.
- 배포된 maven repository를 README 파일에 추가합니다.
