### PR TITLE
Fix: poi 의존성을 implementation에서 api로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    id 'java'
+    id 'java-library'
     id "com.vanniktech.maven.publish" version "0.28.0"
     id 'signing'
     id 'jacoco' // JaCoCo
@@ -38,8 +38,8 @@ repositories {
 
 dependencies {
     //poi
-    implementation 'org.apache.poi:poi:5.4.0'
-    implementation 'org.apache.poi:poi-ooxml:5.4.0'
+    api 'org.apache.poi:poi:5.4.0'
+    api 'org.apache.poi:poi-ooxml:5.4.0'
 
     //logging
     implementation 'org.slf4j:slf4j-api:2.0.17'


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- close #37 


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- api를 사용하기 위해 plugins을 `java`에서 `java-library`로 변경합니다.
- poi 의존성을 `implementation`에서 `api`로 변경합니다.
