### PR TITLE
Refactor: VerticalAlignment의 default 값을 CENTER로 설정

### DIFF
--- a/src/main/java/io/github/hee9841/excel/style/align/CustomExcelAlign.java
+++ b/src/main/java/io/github/hee9841/excel/style/align/CustomExcelAlign.java
@@ -5,7 +5,7 @@ import io.github.hee9841.excel.style.align.alignment.VerticalAlignment;
 import org.apache.poi.ss.usermodel.CellStyle;
 
 /**
- * Implementation of ExcelAlign that allows for custom configuration of 
+ * Implementation of ExcelAlign that allows for custom configuration of
  * horizontal and vertical alignment settings for Excel cells.
  * This class provides flexibility by allowing either or both alignment types to be specified.
  */
@@ -24,7 +24,7 @@ public class CustomExcelAlign implements ExcelAlign {
      * Creates a CustomExcelAlign instance with both horizontal and vertical alignment settings.
      *
      * @param horizontalAlignment the horizontal alignment to apply
-     * @param verticalAlignment the vertical alignment to apply
+     * @param verticalAlignment   the vertical alignment to apply
      * @return a new CustomExcelAlign instance
      */
     public static CustomExcelAlign of(HorizontalAlignment horizontalAlignment,
@@ -37,7 +37,7 @@ public class CustomExcelAlign implements ExcelAlign {
 
     /**
      * Creates a CustomExcelAlign instance with only horizontal alignment specified.
-     * Vertical alignment will remain null.
+     * Vertical alignment will be set to VERTICAL_CENTER by default.
      *
      * @param horizontalAlignment the horizontal alignment to apply
      * @return a new CustomExcelAlign instance
@@ -45,7 +45,7 @@ public class CustomExcelAlign implements ExcelAlign {
     public static CustomExcelAlign from(HorizontalAlignment horizontalAlignment) {
         return new CustomExcelAlign(
             horizontalAlignment,
-            null
+            VerticalAlignment.VERTICAL_CENTER
         );
     }
 

--- a/src/test/java/io/github/hee9841/excel/meta/CellStyleMappingTest.java
+++ b/src/test/java/io/github/hee9841/excel/meta/CellStyleMappingTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.hee9841.excel.annotation.Excel;
-import io.github.hee9841.excel.annotation.ExcelColumnStyle;
 import io.github.hee9841.excel.annotation.ExcelColumn;
+import io.github.hee9841.excel.annotation.ExcelColumnStyle;
 import io.github.hee9841.excel.exception.ExcelStyleException;
 import io.github.hee9841.excel.style.CustomExcelCellStyle;
 import io.github.hee9841.excel.style.ExcelCellStyle;
@@ -56,6 +56,8 @@ public class CellStyleMappingTest {
             blackCenterThin.setFillPattern(FillPatternType.SOLID_FOREGROUND);
 
             blackCenterThin.setAlignment(org.apache.poi.ss.usermodel.HorizontalAlignment.CENTER);
+            blackCenterThin.setVerticalAlignment(
+                org.apache.poi.ss.usermodel.VerticalAlignment.CENTER);
 
             blackCenterThin.setBorderTop(org.apache.poi.ss.usermodel.BorderStyle.THIN);
             blackCenterThin.setBorderBottom(org.apache.poi.ss.usermodel.BorderStyle.THIN);
@@ -120,7 +122,7 @@ public class CellStyleMappingTest {
 
         @DisplayName("class cell style 경우 지정한 cell style이 적용되어야한다.(@ExcelColumn이 @Excel 보다 우선 적용됨)")
         @Test
-        void classCellStyle_applySuccess() {       
+        void classCellStyle_applySuccess() {
             //given
             @Excel(
                 defaultHeaderStyle = @ExcelColumnStyle(cellStyleClass = WhiteGeneralCenterTopThin.class)

--- a/src/test/java/io/github/hee9841/excel/style/align/CustomExcelAlignTest.java
+++ b/src/test/java/io/github/hee9841/excel/style/align/CustomExcelAlignTest.java
@@ -34,7 +34,8 @@ class CustomExcelAlignTest {
         align.applyAlign(cellStyle);
 
         then(cellStyle).should().setAlignment(poiHorizontal);
-        then(cellStyle).shouldHaveNoMoreInteractions();
+        then(cellStyle).should()
+            .setVerticalAlignment(org.apache.poi.ss.usermodel.VerticalAlignment.CENTER);
     }
 
     @DisplayName("from(VerticalAlignment) 메서드는 vertical만 설정되어야 한다.")


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- closes #41 


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 기존 VerticalAlignment값이 null이면 설정을 하지 않았던 것(BOTTOM으로 설정됨)에서 default 값을  CENTER로 설정합니다.
