### PR TITLE
Refactor: 워크북 제네릭 변경으로 교체 가능하게

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter:'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
 
     // mockito
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -9,7 +9,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -40,11 +39,8 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractExcelExporter.class);
 
-    protected static final SpreadsheetVersion supplyExcelVersion = SpreadsheetVersion.EXCEL2007;
-
     protected W workbook;
     protected Map<Integer, ColumnInfo> columnsMappingInfo;
-
     protected String dtoTypeName;
 
     /**
@@ -52,8 +48,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      */
     protected AbstractExcelExporter(W workbook) {
         if (workbook == null) {
-//            throw new NullPointerException("workbook is null");
-            throw new ExcelException("Workbook is null.");
+            throw new ExcelException("Workbook cannot be null");
         }
         this.workbook = workbook;
     }
@@ -65,7 +60,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      * @param type The class type of the data to be exported
      * @param data The list of data objects to be exported
      */
-    protected void initialize(Class<?> type, List<T> data) {
+    protected final void initialize(Class<?> type, List<T> data) {
         this.dtoTypeName = type.getName();
         logger.info("Initializing Excel file for DTO: {}.java.", dtoTypeName);
 
@@ -76,95 +71,6 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
         this.columnsMappingInfo = ColumnInfoMapper.of(type, workbook).map();
     }
 
-
-    /**
-     * Creates headers using the column mapping information.
-     *
-     * @param sheet      The sheet to add headers to
-     * @param headerRowIndex The headers row index
-     */
-    protected void createHeader(Sheet sheet, Integer headerRowIndex) {
-        Row row = sheet.createRow(headerRowIndex);
-        for (Integer colIndex : columnsMappingInfo.keySet()) {
-            ColumnInfo columnMappingInfo = columnsMappingInfo.get(colIndex);
-            Cell cell = row.createCell(colIndex);
-            cell.setCellValue(columnMappingInfo.getHeaderName());
-            cell.setCellStyle(columnMappingInfo.getHeaderStyle());
-        }
-    }
-
-    /**
-     * Creates a new sheet with headers.
-     *
-     * <p>This method resets the current row index, creates a new sheet, and adds headers to it.
-     * If a sheet name is provided, it will be used as a base name with an index(index starts from
-     * 0) suffix.</p>
-     */
-    protected Sheet createNewSheet(String sheetName, int sheetIndex) {
-        //If sheet name is provided, create sheet with sheet name + idx
-        final String finalSheetName = (sheetName != null)
-            ? String.format("%s(%d)", sheetName, sheetIndex)
-            : null;
-
-
-        Sheet sheet = (finalSheetName != null)
-            ? workbook.createSheet(finalSheetName)
-            : workbook.createSheet();
-
-        logger.debug("Create new Sheet : {}.", sheet.getSheetName());
-
-        return sheet;
-    }
-
-    /**
-     * Creates a row in the Excel sheet for the given data object.
-     * This method handles field access and cell value setting based on column mapping information.
-     *
-     * @param sheet    The Sheet object to create a row.
-     * @param data     The data object for rendering data to cell
-     * @param rowIndex The index of the row to create
-     * @throws ExcelException if field access fails
-     */
-    protected void createBody(Sheet sheet, Object data, int rowIndex) {
-        logger.debug("Add rows data - row:{}.", rowIndex);
-        Row row = sheet.createRow(rowIndex);
-        for (Integer colIndex : columnsMappingInfo.keySet()) {
-            ColumnInfo columnInfo = columnsMappingInfo.get(colIndex);
-            try {
-                Field field = FieldUtils.getField(data.getClass(), columnInfo.getFieldName(), true);
-                Cell cell = row.createCell(colIndex);
-                //Set cell value by cell type
-                columnInfo.getColumnType().setCellValueByCellType(cell, field.get(data));
-                //Set cell style
-                cell.setCellStyle(columnInfo.getBodyStyle());
-            } catch (IllegalAccessException e) {
-                throw new ExcelException(
-                    String.format("Failed to create body(column:%d, row:%d) : "
-                            + "Access to field %s failed.",
-                        colIndex, rowIndex, columnInfo.getFieldName()), e);
-            }
-        }
-    }
-
-    /**
-     * Writes the Excel file content to the specified output stream.
-     * This method ensures proper resource cleanup using try-with-resources.
-     *
-     * @param stream The output stream to write the Excel file to
-     * @throws IOException if an I/O error occurs during writing
-     */
-    @Override
-    public final void write(OutputStream stream) throws IOException {
-        if (stream == null) {
-            throw new ExcelException("Output stream is null.");
-        }
-        logger.info("Start to write Excel file for DTO class({}.java).", dtoTypeName);
-
-        try (W autoCloseableWb = this.workbook) {
-            autoCloseableWb.write(stream);
-            logger.info("Successfully wrote Excel file for DTO class({}.java).", dtoTypeName);
-        }
-    }
 
     /**
      * Validates the provided data and type.
@@ -183,5 +89,117 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      * @param data The list of data objects to be exported
      */
     protected abstract void createExcel(List<T> data);
+
+    /**
+     * Adds additional rows to the existing Excel file.
+     * This method must be implemented by subclasses according to their specific
+     * sheet management strategy and workbook type.
+     *
+     * @param data The list of data objects to be added as rows
+     */
+    @Override
+    public abstract void addRows(List<T> data);
+
+
+
+
+    /**
+     * Creates a new sheet.
+     *
+     * <p> If a sheet name is provided, it will be used as a base name with an index (index starts
+     * from 0) suffix.</p>
+     *
+     * @param sheetNamePrefix Base name for sheets (null for default names)
+     * @param sheetIndex      Index used to suffix the sheet name
+     * @return The newly created sheet
+     */
+    protected final Sheet createSheet(String sheetNamePrefix, int sheetIndex) {
+        //If sheet name is provided, create sheet with sheet name + idx
+        final String finalSheetName = (sheetNamePrefix != null)
+            ? String.format("%s(%d)", sheetNamePrefix, sheetIndex)
+            : null;
+
+
+        Sheet sheet = (finalSheetName != null)
+            ? workbook.createSheet(finalSheetName)
+            : workbook.createSheet();
+
+        logger.debug("Create new Sheet : {}.", sheet.getSheetName());
+
+        return sheet;
+    }
+
+
+    /**
+     * Creates a header row using the column mapping information.
+     *
+     * @param sheet The sheet to add headers to
+     * @param headerRowIndex The row index where headers should be created (0-based)
+     */
+    protected final void createHeader(Sheet sheet, Integer headerRowIndex) {
+        Row row = sheet.createRow(headerRowIndex);
+        for (Integer colIndex : columnsMappingInfo.keySet()) {
+            ColumnInfo columnMappingInfo = columnsMappingInfo.get(colIndex);
+            Cell cell = row.createCell(colIndex);
+            cell.setCellValue(columnMappingInfo.getHeaderName());
+            cell.setCellStyle(columnMappingInfo.getHeaderStyle());
+        }
+        logger.debug("Created header row at index {}", headerRowIndex);
+    }
+
+    /**
+     * Creates a row in the Excel sheet for the given data object.
+     * This method handles field access and cell value setting based on column mapping information.
+     *
+     * @param sheet    The Sheet object to create a row.
+     * @param data     The data object for rendering data to cell
+     * @param rowIndex The index of the row to create
+     * @throws ExcelException if field access fails
+     */
+    protected final void createRow(Sheet sheet, Object data, int rowIndex) {
+        logger.debug("Add rows data - row:{}.", rowIndex);
+        Row row = sheet.createRow(rowIndex);
+
+        for (Integer colIndex : columnsMappingInfo.keySet()) {
+            ColumnInfo columnInfo = columnsMappingInfo.get(colIndex);
+            try {
+                Field field = FieldUtils.getField(data.getClass(), columnInfo.getFieldName(), true);
+                Cell cell = row.createCell(colIndex);
+
+                //Set cell value by cell type
+                columnInfo.getColumnType().setCellValueByCellType(cell, field.get(data));
+
+                //Set cell style
+                cell.setCellStyle(columnInfo.getBodyStyle());
+            } catch (IllegalAccessException e) {
+                throw new ExcelException(
+                    String.format("Failed to create body(column:%d, row:%d) : "
+                            + "Access to field %s failed.",
+                        colIndex, rowIndex, columnInfo.getFieldName()), e);
+            }
+        }
+    }
+
+
+    /**
+     * Writes the Excel file content to the specified output stream.
+     * This method ensures proper resource cleanup using try-with-resources.
+     *
+     * @param stream The output stream to write the Excel file to
+     * @throws IOException if an I/O error occurs during writing
+     * @throws NullPointerException if stream is null
+     */
+    @Override
+    public final void write(OutputStream stream) throws IOException, NullPointerException {
+        if (stream == null) {
+            throw new NullPointerException("Output stream is null.");
+        }
+        logger.info("Start to write Excel file for DTO class({}.java).", dtoTypeName);
+
+        try (W autoCloseableWb = this.workbook) {
+            autoCloseableWb.write(stream);
+            logger.info("Successfully wrote Excel file for DTO class({}.java).", dtoTypeName);
+        }
+    }
 
 }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -13,20 +13,19 @@ import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Abstract base class for Excel file operations using Apache POI's SXSSF (Streaming XML Spreadsheet
- * Format).
- * This class provides the core functionality for handling Excel files with streaming support for
- * large datasets.
+ * Abstract base class for Excel file operations using Apache POI's Workbook abstraction.
+ * This class provides the core functionality for handling Excel files with different Workbook
+ * implementations.
  *
  * <p>Key features:</p>
  * <ul>
- *     <li>Uses SXSSFWorkbook for memory-efficient handling of large Excel files</li>
- *     <li>Supports Excel 2007+ format (XLSX)</li>
+ *     <li>Supports different Workbook implementations</li>
+ *     <li>Supports Excel 2007+ format (XLSX) by default</li>
  *     <li>Provides column mapping and header generation</li>
  *     <li>Handles cell styling and data type conversion</li>
  * </ul>
@@ -35,23 +34,28 @@ import org.slf4j.LoggerFactory;
  * to be implemented by concrete subclasses.</p>
  *
  * @param <T> The type of data to be handled in the Excel file
+ * @param <W> The workbook implementation type
  */
-public abstract class AbstractExcelExporter<T> implements ExcelExporter<T> {
+public abstract class AbstractExcelExporter<T, W extends Workbook> implements ExcelExporter<T> {
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractExcelExporter.class);
 
     protected static final SpreadsheetVersion supplyExcelVersion = SpreadsheetVersion.EXCEL2007;
 
-    protected SXSSFWorkbook workbook;
+    protected W workbook;
     protected Map<Integer, ColumnInfo> columnsMappingInfo;
 
     protected String dtoTypeName;
 
     /**
-     * Constructs a new AbstractExcelExporter with a new SXSSFWorkbook instance.
+     * Constructs a new AbstractExcelExporter with the provided workbook instance.
      */
-    protected AbstractExcelExporter() {
-        this.workbook = new SXSSFWorkbook();
+    protected AbstractExcelExporter(W workbook) {
+        if (workbook == null) {
+//            throw new NullPointerException("workbook is null");
+            throw new ExcelException("Workbook is null.");
+        }
+        this.workbook = workbook;
     }
 
     /**
@@ -156,7 +160,7 @@ public abstract class AbstractExcelExporter<T> implements ExcelExporter<T> {
         }
         logger.info("Start to write Excel file for DTO class({}.java).", dtoTypeName);
 
-        try (SXSSFWorkbook autoCloseableWb = this.workbook) {
+        try (W autoCloseableWb = this.workbook) {
             autoCloseableWb.write(stream);
             logger.info("Successfully wrote Excel file for DTO class({}.java).", dtoTypeName);
         }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -4,6 +4,7 @@ import io.github.hee9841.excel.exception.ExcelException;
 import io.github.hee9841.excel.strategy.SheetStrategy;
 import java.text.MessageFormat;
 import java.util.List;
+import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
@@ -29,21 +30,17 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
  */
 public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
 
-    private static final String EXCEED_MAX_ROW_MSG_2ARGS =
-        "The data size exceeds the maximum number of rows allowed per sheet. "
-            + "The sheet strategy is set to ONE_SHEET but the data size is larger than "
-            + "the maximum rows per sheet (data size: {0}, maximum rows: {1} ).\n"
-            + "Please change the sheet strategy to MULTI_SHEET or reduce the data size.";
+    private static final SpreadsheetVersion supplyExcelVersion = SpreadsheetVersion.EXCEL2007;
+    private static final int HEADER_ROW_INDEX = 0;
 
-    private static final int ROW_START_INDEX = 0;
-    private int currentRowIndex = ROW_START_INDEX;
-
-    private final String sheetName;
-    private final int maxRowsPerSheet;
+    private final String sheetNamePrefix;
+    private final int maxRowsIndexPerSheet;
 
     private SheetStrategy sheetStrategy;
 
     private Sheet currentSheet;
+    private int currentRowIndex = HEADER_ROW_INDEX;
+    private int currentSheetIndex;
 
 
     /**
@@ -66,11 +63,16 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
         int maxRowsPerSheet
     ) {
         super(new SXSSFWorkbook());
-        this.maxRowsPerSheet = maxRowsPerSheet;
-        this.sheetName = sheetName;
-        setSheetStrategy(sheetStrategy);
 
+        this.sheetNamePrefix = sheetName;
+        this.maxRowsIndexPerSheet = maxRowsPerSheet - 1;
+        this.currentSheetIndex = HEADER_ROW_INDEX;
+
+        setSheetStrategy(sheetStrategy);
+        // Initialize column mapping
         this.initialize(type, data);
+
+        //create Excel
         this.createExcel(data);
     }
 
@@ -92,7 +94,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      *
      * <p>This method also configures the workbook's Zip64 mode based on the selected strategy.</p>
      *
-     * @param strategy The sheet strategy to use (ONE_SHEET or MULTI_SHEET)-
+     * @param strategy The sheet strategy to use (ONE_SHEET or MULTI_SHEET)
      */
     private void setSheetStrategy(SheetStrategy strategy) {
 
@@ -116,10 +118,14 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      */
     @Override
     protected void validate(Class<?> type, List<T> data) {
-        if (SheetStrategy.isOneSheet(sheetStrategy) && data.size() > maxRowsPerSheet - 1) {
+        if (SheetStrategy.isOneSheet(sheetStrategy) && data.size() > maxRowsIndexPerSheet) {
             throw new ExcelException(
-                MessageFormat.format(EXCEED_MAX_ROW_MSG_2ARGS,
-                    data.size(), maxRowsPerSheet
+                MessageFormat.format(
+                    "The data size exceeds the maximum number of data rows allowed per sheet. "
+                        + "The sheet strategy is set to ONE_SHEET but the data size is larger than "
+                        + "the maximum data rows per sheet (excluding header) (data size: {0}, maximum data rows: {1}).\n"
+                        + "Please change the sheet strategy to MULTI_SHEET or reduce the data size.",
+                    data.size(), maxRowsIndexPerSheet
                 ), dtoTypeName);
         }
     }
@@ -137,9 +143,8 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      */
     @Override
     protected void createExcel(List<T> data) {
-
-        currentSheet = createNewSheet(sheetName, 0);
-        createHeader(currentSheet, ROW_START_INDEX);
+        // Initialize first sheet with headers
+        initializeNewSheet();
 
         // 1. If data is empty, create createHeader only.
         if (data.isEmpty()) {
@@ -149,7 +154,9 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
 
         //2. Add Rows
         addRows(data);
+
     }
+
 
     /**
      * Adds rows to the current sheet for the provided data list.
@@ -157,43 +164,41 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      * <p>If the number of rows exceeds the maximum allowed per sheet and the sheet strategy
      * is MULTI_SHEET, a new sheet will be created to continue adding rows.</p>
      *
-     * <p>If the sheet strategy is ONE_SHEET and the data size exceeds the maximum rows per sheet,
-     * an ExcelException will be thrown.</p>
+     * <p>If the sheet strategy is ONE_SHEET and the data size exceeds the remaining rows
+     * in the current sheet, an ExcelException will be thrown.</p>
      *
      * @param data The list of data objects to be added as rows
      * @throws ExcelException if ONE_SHEET strategy is used and data exceeds max rows limit
      */
     @Override
     public void addRows(List<T> data) {
-        int leftDataSize = data.size();
-        for (Object renderedData : data) {
-            createBody(currentSheet, renderedData, currentRowIndex++);
-            leftDataSize--;
-            if (currentRowIndex == maxRowsPerSheet && leftDataSize > 0) {
-                //If one sheet strategy, throw exception
-                if (SheetStrategy.isOneSheet(sheetStrategy)) {
-                    throw new ExcelException(
-                        MessageFormat.format(EXCEED_MAX_ROW_MSG_2ARGS,
-                            data.size(), maxRowsPerSheet), dtoTypeName);
-                }
+        // If sheet strategy ONE_SHEET and ata size exceeds the remaining rows, throw Exception
+        if (SheetStrategy.isOneSheet(sheetStrategy) &&
+            (data.size() > maxRowsIndexPerSheet - currentRowIndex)
+        ) {
+            throw new ExcelException(
+                MessageFormat.format(
+                    "The data size exceeds the remaining data rows in the current sheet. "
+                        + "The sheet strategy is set to ONE_SHEET but the data size is larger than "
+                        + "the remaining data rows (data size: {0}, remaining data rows: {1}, maximum data rows per sheet (excluding header): {2}).\n"
+                        + "Please change the sheet strategy to MULTI_SHEET or reduce the data size.",
+                    data.size(), (maxRowsIndexPerSheet - currentRowIndex), maxRowsIndexPerSheet),
+                dtoTypeName);
+        }
 
-                //If multi sheet strategy, create new sheet
-                currentRowIndex = ROW_START_INDEX;
-                currentSheet = createNewSheet(sheetName, workbook.getSheetIndex(currentSheet) + 1);
-                createHeader(currentSheet, ROW_START_INDEX);
+
+        for (T rowData : data) {
+            if (currentRowIndex >= maxRowsIndexPerSheet) {
+                initializeNewSheet();
             }
+            createRow(currentSheet, rowData, ++currentRowIndex);
         }
     }
 
-    /**
-     * Override createHeader Method to add currentRowIndex.
-     *
-     * @param sheet      The sheet to add headers to
-     * @param headerRowIndex The headers row index
-     */
-    @Override
-    protected void createHeader(Sheet sheet, Integer headerRowIndex) {
-        super.createHeader(sheet, headerRowIndex);
-        currentRowIndex++;
+    private void initializeNewSheet() {
+        currentSheet = createSheet(sheetNamePrefix, currentSheetIndex++);
+        currentRowIndex = HEADER_ROW_INDEX;
+        createHeader(currentSheet, currentRowIndex);
     }
+
 }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -5,6 +5,7 @@ import io.github.hee9841.excel.strategy.SheetStrategy;
 import java.text.MessageFormat;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 /**
  * SXSSFExporter is a concrete implementation of {@link AbstractExcelExporter} that provides functionality
@@ -26,7 +27,7 @@ import org.apache.poi.ss.usermodel.Sheet;
  * @see SXSSFExporterBuilder
  * @see SheetStrategy
  */
-public class SXSSFExporter<T> extends AbstractExcelExporter<T> {
+public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
 
     private static final String EXCEED_MAX_ROW_MSG_2ARGS =
         "The data size exceeds the maximum number of rows allowed per sheet. "
@@ -64,7 +65,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T> {
         String sheetName,
         int maxRowsPerSheet
     ) {
-        super();
+        super(new SXSSFWorkbook());
         this.maxRowsPerSheet = maxRowsPerSheet;
         this.sheetName = sheetName;
         setSheetStrategy(sheetStrategy);

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
@@ -53,7 +53,7 @@ public class SXSSFExporterBuilder<T> {
         this.type = type;
         this.data = data;
         this.supplyExcelMaxRows = supplyExcelMaxRows;
-        this.maxRowsPerSheet = supplyExcelMaxRows - 1;
+        this.maxRowsPerSheet = supplyExcelMaxRows;
         this.sheetStrategy = SheetStrategy.MULTI_SHEET;
         this.sheetName = null;
     }
@@ -77,10 +77,10 @@ public class SXSSFExporterBuilder<T> {
      * @throws ExcelException if maxRowsPerSheet exceeds the Excel version's maximum row limit
      */
     public SXSSFExporterBuilder<T> maxRows(int maxRowsPerSheet) {
-        if (maxRowsPerSheet > supplyExcelMaxRows) {
+        if (maxRowsPerSheet > supplyExcelMaxRows || maxRowsPerSheet < 2) {
             throw new ExcelException(String.format(
-                "The maximum rows per sheet(%d) cannot exceed the supplied Excel sheet version's maximum row limit(%d).",
-                maxRowsPerSheet, supplyExcelMaxRows));
+                "maxRowsPerSheet must be between 2 and %d (inclusive). Provided: %d.",
+                supplyExcelMaxRows, maxRowsPerSheet));
         }
         this.maxRowsPerSheet = maxRowsPerSheet;
         return this;

--- a/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
@@ -1,0 +1,84 @@
+package io.github.hee9841.excel.core.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.hee9841.excel.exception.ExcelException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AbstractExcelExporter 테스트")
+class AbstractExcelExporterTest {
+
+    @DisplayName("워크북이 null이면 예외를 발생한다.")
+    @Test
+    void throwsExceptionWhenWorkbookIsNull() {
+        assertThrows(ExcelException.class, () -> new TestExporter(null));
+    }
+
+    @DisplayName("시트 이름 프리픽스를 사용해 시트를 생성한다.")
+    @Test
+    void createSheetWithPrefix() throws IOException {
+        //given
+        String prefix = "MYSheet";
+        int sheetIndex = 0;
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        //when
+        Sheet sheet = testExporter.createSheet(prefix, sheetIndex);
+
+        //then
+        assertThat(sheet.getSheetName()).startsWith(prefix);
+        assertEquals(sheetIndex, wb.getSheetIndex(sheet));
+
+        wb.close();
+    }
+
+    @DisplayName("write에 null stream을 전달하면 NPE를 발생한다.")
+    @Test
+    void writeThrowsExceptionWhenStreamIsNull() {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        assertThrows(NullPointerException.class, () -> testExporter.write(null));
+    }
+
+    @DisplayName("워크북이 정상적으로 write 된다.")
+    @Test
+    void writeWorkbook() throws IOException {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            testExporter.write(outputStream);
+            assertThat(outputStream.toByteArray().length).isGreaterThan(0);
+        }
+    }
+
+    private static class TestExporter extends AbstractExcelExporter<Object, Workbook> {
+
+        private TestExporter(Workbook workbook) {
+            super(workbook);
+        }
+
+        @Override
+        protected void validate(Class<?> type, List<Object> data) {
+        }
+
+        @Override
+        protected void createExcel(List<Object> data) {
+        }
+
+        @Override
+        public void addRows(List<Object> data) {
+        }
+    }
+}

--- a/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
@@ -1,0 +1,76 @@
+package io.github.hee9841.excel.core.exporter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.hee9841.excel.annotation.Excel;
+import io.github.hee9841.excel.annotation.ExcelColumn;
+import io.github.hee9841.excel.strategy.CellTypeStrategy;
+import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ExcelExporter interface 테스트")
+class ExcelExporterTest {
+
+    @DisplayName("인터페이스 타입으로 addRows 후 write가 정상 동작한다.")
+    @Test
+    void addRowsAndWriteViaInterface() throws IOException {
+        // given
+        List<TestDto> initialData = List.of(
+            new TestDto("alpha", 1),
+            new TestDto("beta", 2)
+        );
+
+        ExcelExporter<TestDto> exporter = SXSSFExporter.builder(TestDto.class, initialData)
+            .maxRows(5)
+            .build();
+
+        // when
+        exporter.addRows(List.of(new TestDto("gamma", 3)));
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            exporter.write(os);
+
+            // then
+            try (Workbook workbook = WorkbookFactory.create(
+                new ByteArrayInputStream(os.toByteArray()))) {
+                Sheet sheet = workbook.getSheetAt(0);
+                assertEquals("name", sheet.getRow(0).getCell(0).getStringCellValue());
+                assertEquals("number", sheet.getRow(0).getCell(1).getStringCellValue());
+
+                assertEquals("alpha", sheet.getRow(1).getCell(0).getStringCellValue());
+                assertEquals(1, (int) sheet.getRow(1).getCell(1).getNumericCellValue());
+
+                assertEquals("beta", sheet.getRow(2).getCell(0).getStringCellValue());
+                assertEquals(2, (int) sheet.getRow(2).getCell(1).getNumericCellValue());
+
+                assertEquals("gamma", sheet.getRow(3).getCell(0).getStringCellValue());
+                assertEquals(3, (int) sheet.getRow(3).getCell(1).getNumericCellValue());
+            }
+        }
+    }
+
+    @Excel(
+        columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
+        cellTypeStrategy = CellTypeStrategy.AUTO
+    )
+    static class TestDto {
+        @ExcelColumn(headerName = "name", columnIndex = 0)
+        private final String name;
+
+        @ExcelColumn(headerName = "number", columnIndex = 1)
+        private final int number;
+
+        TestDto(String name, int number) {
+            this.name = name;
+            this.number = number;
+        }
+    }
+}

--- a/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
@@ -101,7 +101,7 @@ class SXSSFExporterByteOutputStreamTest {
 
         // Verify the exception message
         assertTrue(exception.getMessage()
-            .contains("The data size exceeds the maximum number of rows allowed per sheet"));
+            .contains("The data size exceeds the maximum number of data rows allowed per sheet"));
     }
 
 
@@ -120,7 +120,24 @@ class SXSSFExporterByteOutputStreamTest {
 
         //then
         assertTrue(exception.getMessage()
-            .contains("cannot exceed the supplied Excel sheet version's maximum row"));
+            .contains("maxRowsPerSheet must be between 2 and"));
+    }
+
+    @DisplayName("maxRows는 2 이상이어야 한다.")
+    @Test
+    void maxRowsMustBeAtLeastTwo() {
+        //given
+        List<TestDto> data = new ArrayList<>();
+
+        // when
+        ExcelException exception = assertThrows(ExcelException.class, () -> SXSSFExporter
+            .builder(TestDto.class, data)
+            .maxRows(1)
+            .build());
+
+        //then
+        assertTrue(exception.getMessage()
+            .contains("maxRowsPerSheet must be between 2 and"));
     }
 
     @DisplayName("엑셀 파일 생성 성공 시, log가 순서대로 생성되어야한다.")
@@ -137,17 +154,18 @@ class SXSSFExporterByteOutputStreamTest {
         exporter.write(os);
 
         //then
-        assertEquals(8, memoryAppender.getSize());
+        assertEquals(9, memoryAppender.getSize());
         assertTrue(memoryAppender.isPresent(0,
             "Set sheet strategy and Zip64Mode - strategy: MULTI_SHEET, Zip64Mode: Always.",
             Level.DEBUG));
         assertTrue(memoryAppender.isPresent(1, "Initializing", Level.INFO));
         assertTrue(memoryAppender.isPresent(2, "Mapping", Level.DEBUG));
         assertTrue(memoryAppender.isPresent(3, "Create new Sheet", Level.DEBUG));
-        assertTrue(memoryAppender.isPresent(4, "Add rows data - row:1", Level.DEBUG));
-        assertTrue(memoryAppender.isPresent(5, "Add rows data - row:2", Level.DEBUG));
-        assertTrue(memoryAppender.isPresent(6, "Start to write Excel file", Level.INFO));
-        assertTrue(memoryAppender.isPresent(7, "Successfully wrote Excel", Level.INFO));
+        assertTrue(memoryAppender.isPresent(4, "Created header row at index 0", Level.DEBUG));
+        assertTrue(memoryAppender.isPresent(5, "Add rows data - row:1", Level.DEBUG));
+        assertTrue(memoryAppender.isPresent(6, "Add rows data - row:2", Level.DEBUG));
+        assertTrue(memoryAppender.isPresent(7, "Start to write Excel file", Level.INFO));
+        assertTrue(memoryAppender.isPresent(8, "Successfully wrote Excel", Level.INFO));
     }
 
 
@@ -175,7 +193,7 @@ class SXSSFExporterByteOutputStreamTest {
             assertNull(sheet.getRow(1));
         }
 
-        assertEquals(7, memoryAppender.countEventsForLogger(loggerClassName));
+        assertEquals(8, memoryAppender.countEventsForLogger(loggerClassName));
         assertTrue(memoryAppender.isPresent("Empty data provided", Level.WARN));
     }
 
@@ -245,7 +263,7 @@ class SXSSFExporterByteOutputStreamTest {
 
             //then
             assertTrue(exception.getMessage()
-                .contains("The data size exceeds the maximum number of rows allowed per sheet."));
+                .contains("The data size exceeds the maximum number of data rows allowed per sheet."));
 
             //
             assertEquals(2, memoryAppender.getSize());
@@ -282,6 +300,32 @@ class SXSSFExporterByteOutputStreamTest {
             assertTrue(memoryAppender.isPresent("Create new Sheet : TestSheet(1).", Level.DEBUG));
 
         }
+    }
+
+    @DisplayName("ONE_SHEET 전략에서 addRows가 남은 행을 초과하면 예외를 발생한다.")
+    @Test
+    void addRowsThrowsExceptionWhenExceedRemainingRowsInOneSheet() {
+        // given
+        List<TestDto> initialData = new ArrayList<>();
+        initialData.add(new TestDto("test1", 1));
+        initialData.add(new TestDto("test2", 2));
+        initialData.add(new TestDto("test3", 3));
+
+        SXSSFExporter<TestDto> exporter = SXSSFExporter.builder(TestDto.class, initialData)
+            .maxRows(5)
+            .sheetStrategy(SheetStrategy.ONE_SHEET)
+            .build();
+
+        List<TestDto> additionalData = new ArrayList<>();
+        additionalData.add(new TestDto("test4", 4));
+        additionalData.add(new TestDto("test5", 5));
+
+        // when & then
+        ExcelException exception = assertThrows(ExcelException.class,
+            () -> exporter.addRows(additionalData));
+
+        assertTrue(exception.getMessage()
+            .contains("The data size exceeds the remaining data rows in the current sheet."));
     }
 
     @DisplayName("Formula 타입인 cell는 함수 값이 적용 되어야한다.")
@@ -536,4 +580,3 @@ class SXSSFExporterByteOutputStreamTest {
     }
 
 }
-


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- `AbstractExcelExporter` 추상클래스의 workbook 타입을 SXSSFWorkbook -> Workbook으로 변경합니다.
- Workbook을 제네릭으로 하여 워크북 교체 가능성 확보합니다.
- 위의 변경사항에 따른 테스트 코드 추가
