### PR TITLE
Refactor: 메핑 및 exporter 시 사용되는 메타데이터 타입을 HashMap -> List 로 변경

### DIFF
--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
@@ -40,7 +39,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
     protected static final Logger logger = LoggerFactory.getLogger(AbstractExcelExporter.class);
 
     protected W workbook;
-    protected Map<Integer, ColumnInfo> columnsMappingInfo;
+    protected List<ColumnInfo> columnsMappingInfos;
     protected String dtoTypeName;
 
     /**
@@ -68,7 +67,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
         logger.debug("Mapping DTO to Excel data - DTO class({}).", dtoTypeName);
         //Map DTO to Excel data
-        this.columnsMappingInfo = ColumnInfoMapper.of(type, workbook).map();
+        this.columnsMappingInfos = ColumnInfoMapper.of(type, workbook).map();
     }
 
 
@@ -138,8 +137,8 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      */
     protected final void createHeader(Sheet sheet, Integer headerRowIndex) {
         Row row = sheet.createRow(headerRowIndex);
-        for (Integer colIndex : columnsMappingInfo.keySet()) {
-            ColumnInfo columnMappingInfo = columnsMappingInfo.get(colIndex);
+        for (ColumnInfo columnMappingInfo : columnsMappingInfos) {
+            int colIndex = columnMappingInfo.getIndex();
             Cell cell = row.createCell(colIndex);
             cell.setCellValue(columnMappingInfo.getHeaderName());
             cell.setCellStyle(columnMappingInfo.getHeaderStyle());
@@ -160,8 +159,8 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
         logger.debug("Add rows data - row:{}.", rowIndex);
         Row row = sheet.createRow(rowIndex);
 
-        for (Integer colIndex : columnsMappingInfo.keySet()) {
-            ColumnInfo columnInfo = columnsMappingInfo.get(colIndex);
+        for (ColumnInfo columnInfo : columnsMappingInfos) {
+            int colIndex = columnInfo.getIndex();
             try {
                 Field field = FieldUtils.getField(data.getClass(), columnInfo.getFieldName(), true);
                 Cell cell = row.createCell(colIndex);

--- a/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfo.java
+++ b/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfo.java
@@ -17,6 +17,10 @@ import org.apache.poi.ss.usermodel.CellStyle;
 public class ColumnInfo {
 
     /**
+     * The column index in the Excel sheet
+     */
+    private final int index;
+    /**
      * The name of the Java field this column maps to
      */
     private final String fieldName;
@@ -39,12 +43,14 @@ public class ColumnInfo {
 
 
     private ColumnInfo(
+        int index,
         String fieldName,
         String headerName,
         ColumnDataType columnType,
         CellStyle headerStyle,
         CellStyle bodyStyle
     ) {
+        this.index = index;
         this.fieldName = fieldName;
         this.headerName = headerName;
         this.columnType = columnType;
@@ -55,6 +61,7 @@ public class ColumnInfo {
     /**
      * Factory method to create a new {@link ColumnInfo} instance.
      *
+     * @param index       The column index
      * @param fieldName   The name of the Java field
      * @param headerName  The display name for the Excel header
      * @param columnType  The cell type for this column
@@ -63,15 +70,19 @@ public class ColumnInfo {
      * @return A new {@link ColumnInfo} instance
      */
     public static ColumnInfo of(
+        int index,
         String fieldName,
         String headerName,
         ColumnDataType columnType,
         CellStyle headerStyle,
         CellStyle bodyStyle
     ) {
-        return new ColumnInfo(fieldName, headerName, columnType, headerStyle, bodyStyle);
+        return new ColumnInfo(index, fieldName, headerName, columnType, headerStyle, bodyStyle);
     }
 
+    public int getIndex() {
+        return index;
+    }
 
     public String getFieldName() {
         return fieldName;

--- a/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfoMapper.java
+++ b/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfoMapper.java
@@ -18,9 +18,12 @@ import io.github.hee9841.excel.style.NoCellStyle;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -96,15 +99,14 @@ public class ColumnInfoMapper {
     }
 
     /**
-     * Maps the class fields to Excel columns and returns a map of column indices to
-     * {@link ColumnInfo} objects.
+     * Maps the class fields to Excel columns and returns a list of {@link ColumnInfo} objects.
      * This method processes the {@link io.github.hee9841.excel.annotation.Excel} annotation and
      * all {@link io.github.hee9841.excel.annotation.ExcelColumn} annotations in the class.
      *
-     * @return A map of column indices to {@link ColumnInfo} objects
+     * @return A list of {@link ColumnInfo} objects ordered by column index
      * @throws ExcelException If the class is not properly annotated or has invalid configuration
      */
-    public Map<Integer, ColumnInfo> map() {
+    public List<ColumnInfo> map() {
         parsingExcelAnnotation();
         return parsingExcelColumns().orElseThrow(() -> new ExcelException(
                 String.format("No @ExcelColumn annotations found in class '(%s)'."
@@ -153,17 +155,16 @@ public class ColumnInfoMapper {
 
     /**
      * Parses all fields annotated with {@link io.github.hee9841.excel.annotation.ExcelColumn}
-     * in the class and builds a map of
-     * column indices to {@link ColumnInfo} objects.
+     * in the class and builds a list of {@link ColumnInfo} objects.
      *
-     * @return An Optional containing the map of column indices to {@link ColumnInfo} objects,
-     * or an empty Optional
+     * @return An Optional containing the list of {@link ColumnInfo} objects, or an empty Optional
      * if no {@link io.github.hee9841.excel.annotation.ExcelColumn} annotations were found.
      * @throws ExcelException If there are duplicate column indices or other validation errors
      */
-    private Optional<Map<Integer, ColumnInfo>> parsingExcelColumns() {
+    private Optional<List<ColumnInfo>> parsingExcelColumns() {
         int autoColumnIndexCnt = 0;
-        Map<Integer, ColumnInfo> result = new HashMap<>();
+        List<ColumnInfo> result = new ArrayList<>();
+        Map<Integer, ColumnInfo> indexLookup = new ConcurrentHashMap<>();
 
         for (Field field : FieldUtils.getAllFields(type)) {
             if (!field.isAnnotationPresent(ExcelColumn.class)) {
@@ -179,14 +180,21 @@ public class ColumnInfoMapper {
             int columnIndex = columnIndexStrategy.isFieldOrder()
                 ? autoColumnIndexCnt++
                 : excelColumn.columnIndex();
-            validateColumnIndex(result, columnIndex, field.getName());
+            validateColumnIndex(indexLookup, columnIndex, field.getName());
 
             //get column info
-            result.put(columnIndex,
-                getColumnInfo(excelColumn, field.getType(), field.getName()));
+            ColumnInfo columnInfo = getColumnInfo(
+                columnIndex, excelColumn, field.getType(), field.getName());
+            result.add(columnInfo);
+            indexLookup.put(columnIndex, columnInfo);
         }
 
-        return result.isEmpty() ? Optional.empty() : Optional.of(result);
+        if (result.isEmpty()) {
+            return Optional.empty();
+        }
+
+        result.sort(Comparator.comparingInt(ColumnInfo::getIndex));
+        return Optional.of(result);
     }
 
     private void validateField(Field field) {
@@ -220,7 +228,7 @@ public class ColumnInfoMapper {
     /**
      * Validates a column index to ensure it's not negative and not already in use.
      *
-     * @param columnInfoMap The current map of column indices to {@link ColumnInfo} objects
+     * @param columnInfoMap The current index lookup of {@link ColumnInfo} objects
      * @param columnIndex   The column index to validate
      * @param fieldName     The name of the field being validated
      * @throws ExcelException If the column index is negative or already in use
@@ -251,14 +259,19 @@ public class ColumnInfoMapper {
     /**
      * Creates a {@link ColumnInfo} object for a field based on its {@link ExcelColumn} annotation.
      *
+     * @param columnIndex The column index for the field
      * @param excelColumn The {@link ExcelColumn} annotation
      * @param fieldType   The type of the field
      * @param fieldName   The name of the field
      * @return A {@link ColumnInfo} object with the appropriate settings
      * @throws ExcelException If the {@link ColumnDataType} is not compatible with the field type
      */
-    private ColumnInfo getColumnInfo(ExcelColumn excelColumn, Class<?> fieldType,
-        String fieldName) {
+    private ColumnInfo getColumnInfo(
+        int columnIndex,
+        ExcelColumn excelColumn,
+        Class<?> fieldType,
+        String fieldName
+    ) {
         //Get cell type for column
         ColumnDataType columnDataType = getcolumnDataType(excelColumn.columnCellType(), fieldType,
             fieldName);
@@ -272,6 +285,7 @@ public class ColumnInfoMapper {
         dataFormater.apply(bodyStyle);
 
         return ColumnInfo.of(
+            columnIndex,
             fieldName,
             excelColumn.headerName(),
             columnDataType,

--- a/src/test/java/io/github/hee9841/excel/core/meta/CellStyleMappingTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/meta/CellStyleMappingTest.java
@@ -23,7 +23,7 @@ import io.github.hee9841.excel.style.color.ExcelColor;
 import io.github.hee9841.excel.style.color.PaletteExcelColor;
 import io.github.hee9841.excel.style.configurer.ExcelCellStyleConfigurer;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
+import java.util.List;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -108,15 +108,16 @@ public class CellStyleMappingTest {
             }
 
             //when
-            Map<Integer, ColumnInfo> resultMap = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            assertCellStyleEquals(whiteGeneralCenterTopThin, resultMap.get(0).getHeaderStyle());
-            assertCellStyleEquals(blackCenterThin, resultMap.get(0).getBodyStyle());
+            assertCellStyleEquals(whiteGeneralCenterTopThin,
+                findByIndex(columnInfos, 0).getHeaderStyle());
+            assertCellStyleEquals(blackCenterThin, findByIndex(columnInfos, 0).getBodyStyle());
 
-            assertCellStyleEquals(blackCenterThin, resultMap.get(1).getHeaderStyle());
-            assertCellStyleEquals(wb.createCellStyle(), resultMap.get(1).getBodyStyle());
+            assertCellStyleEquals(blackCenterThin, findByIndex(columnInfos, 1).getHeaderStyle());
+            assertCellStyleEquals(wb.createCellStyle(), findByIndex(columnInfos, 1).getBodyStyle());
         }
 
 
@@ -141,15 +142,16 @@ public class CellStyleMappingTest {
             }
 
             //when
-            Map<Integer, ColumnInfo> resultMap = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            assertCellStyleEquals(whiteGeneralCenterTopThin, resultMap.get(0).getHeaderStyle());
-            assertCellStyleEquals(blackCenterThin, resultMap.get(0).getBodyStyle());
+            assertCellStyleEquals(whiteGeneralCenterTopThin,
+                findByIndex(columnInfos, 0).getHeaderStyle());
+            assertCellStyleEquals(blackCenterThin, findByIndex(columnInfos, 0).getBodyStyle());
 
-            assertCellStyleEquals(blackCenterThin, resultMap.get(1).getHeaderStyle());
-            assertCellStyleEquals(wb.createCellStyle(), resultMap.get(1).getBodyStyle());
+            assertCellStyleEquals(blackCenterThin, findByIndex(columnInfos, 1).getHeaderStyle());
+            assertCellStyleEquals(wb.createCellStyle(), findByIndex(columnInfos, 1).getBodyStyle());
         }
 
 
@@ -169,6 +171,12 @@ public class CellStyleMappingTest {
             assertEquals(expected.getBorderRight(), actual.getBorderRight());
         }
 
+        private ColumnInfo findByIndex(List<ColumnInfo> columnInfos, int index) {
+            return columnInfos.stream()
+                .filter(columnInfo -> columnInfo.getIndex() == index)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Column index not found: " + index));
+        }
 
     }
 

--- a/src/test/java/io/github/hee9841/excel/core/meta/ColumnInfoMapperTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/meta/ColumnInfoMapperTest.java
@@ -16,7 +16,7 @@ import io.github.hee9841.excel.strategy.DataFormatStrategy;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
-import java.util.Map;
+import java.util.List;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,14 +98,14 @@ class ColumnInfoMapperTest {
                 .of(TestExcelDto.class, wb);
 
             //when
-            Map<Integer, ColumnInfo> map = columnInfoMapper.map();
+            List<ColumnInfo> columnInfos = columnInfoMapper.map();
 
             //then
-            ColumnInfo firstCol = map.get(0);
+            ColumnInfo firstCol = findByIndex(columnInfos, 0);
             assertEquals("firstHeader", firstCol.getHeaderName());
             assertEquals("firstField", firstCol.getFieldName());
 
-            ColumnInfo secondCol = map.get(1);
+            ColumnInfo secondCol = findByIndex(columnInfos, 1);
             assertEquals("secondHeader", secondCol.getHeaderName());
             assertEquals("secondField", secondCol.getFieldName());
         }
@@ -127,14 +127,14 @@ class ColumnInfoMapperTest {
                 .of(TestExcelDto.class, wb);
 
             //when
-            Map<Integer, ColumnInfo> map = columnInfoMapper.map();
+            List<ColumnInfo> columnInfos = columnInfoMapper.map();
 
             //then
-            ColumnInfo firstCol = map.get(5);
+            ColumnInfo firstCol = findByIndex(columnInfos, 5);
             assertEquals("firstHeader", firstCol.getHeaderName());
             assertEquals("firstField", firstCol.getFieldName());
 
-            ColumnInfo secondCol = map.get(4);
+            ColumnInfo secondCol = findByIndex(columnInfos, 4);
             assertEquals("secondHeader", secondCol.getHeaderName());
             assertEquals("secondField", secondCol.getFieldName());
         }
@@ -159,12 +159,12 @@ class ColumnInfoMapperTest {
                 .of(TestExcelDto.class, wb);
 
             //when
-            Map<Integer, ColumnInfo> map = columnInfoMapper.map();
+            List<ColumnInfo> columnInfos = columnInfoMapper.map();
 
             //then
-            assertEquals("일", map.get(0).getHeaderName());
-            assertEquals("이", map.get(1).getHeaderName());
-            assertEquals("삼", map.get(2).getHeaderName());
+            assertEquals("일", findByIndex(columnInfos, 0).getHeaderName());
+            assertEquals("이", findByIndex(columnInfos, 1).getHeaderName());
+            assertEquals("삼", findByIndex(columnInfos, 2).getHeaderName());
         }
 
         @DisplayName("column index mapping 예외")
@@ -289,15 +289,14 @@ class ColumnInfoMapperTest {
         @Test
         void cellTypeStrategyIsAuto_applyAutoType() {
             //given && when
-            Map<Integer, ColumnInfo> map = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TypeAutoDto.class, wb).map();
 
             //then
-            assertEquals("primitiveInt", map.get(0).getFieldName());
-            assertEquals("numberField", map.get(0).getHeaderName());
+            assertEquals("primitiveInt", findByIndex(columnInfos, 0).getFieldName());
+            assertEquals("numberField", findByIndex(columnInfos, 0).getHeaderName());
 
-            for (Integer i : map.keySet()) {
-                ColumnInfo columnInfo = map.get(i);
+            for (ColumnInfo columnInfo : columnInfos) {
 
                 switch (columnInfo.getHeaderName()) {
                     case "numberField":
@@ -334,11 +333,11 @@ class ColumnInfoMapperTest {
             }
 
             //when
-            Map<Integer, ColumnInfo> map = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            assertEquals(ColumnDataType._NONE, map.get(0).getColumnType());
+            assertEquals(ColumnDataType._NONE, findByIndex(columnInfos, 0).getColumnType());
         }
     }
 
@@ -385,12 +384,11 @@ class ColumnInfoMapperTest {
             }
 
             // && when
-            Map<Integer, ColumnInfo> map = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            for (Integer key : map.keySet()) {
-                ColumnInfo columnInfo = map.get(key);
+            for (ColumnInfo columnInfo : columnInfos) {
                 String formatString = columnInfo.getBodyStyle().getDataFormatString();
                 assertFormatByHeaderName(columnInfo.getHeaderName(), formatString);
 
@@ -455,12 +453,11 @@ class ColumnInfoMapperTest {
             }
 
             // && when
-            Map<Integer, ColumnInfo> map = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            for (Integer key : map.keySet()) {
-                ColumnInfo columnInfo = map.get(key);
+            for (ColumnInfo columnInfo : columnInfos) {
                 String formatString = columnInfo.getBodyStyle().getDataFormatString();
                 assertFormatByHeaderName(columnInfo.getHeaderName(), formatString);
 
@@ -501,12 +498,11 @@ class ColumnInfoMapperTest {
             }
 
             // && when
-            Map<Integer, ColumnInfo> map = ColumnInfoMapper
+            List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TestDto.class, wb).map();
 
             //then
-            for (Integer key : map.keySet()) {
-                ColumnInfo columnInfo = map.get(key);
+            for (ColumnInfo columnInfo : columnInfos) {
                 String formatString = columnInfo.getBodyStyle().getDataFormatString();
                 assertFormatByHeaderName(columnInfo.getHeaderName(), formatString);
 
@@ -536,6 +532,13 @@ class ColumnInfoMapperTest {
                     break;
             }
         }
+    }
+
+    private ColumnInfo findByIndex(List<ColumnInfo> columnInfos, int index) {
+        return columnInfos.stream()
+            .filter(columnInfo -> columnInfo.getIndex() == index)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Column index not found: " + index));
     }
 
 }


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 메핑 및 exporter 시 사용되는 메타데이터(columnInfoMap 타입을 HashMap -> List 로 변경합니다.
