### PR TITLE
Refactor : Exporter에 AutoCloseable 상속

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ Controls how sheets are created when exporting data:
 
 ### Common Issues
 
+**Q: Is this library thread-safe?**  
+A: No. The exporters and underlying Apache POI `Workbook`/`CellStyle` objects are not thread-safe.  
+Create a new exporter per thread/request and do not share exporter instances across threads.
+
 **Q: Numbers are stored as text in Excel instead of numeric values**  
 A: You can fix this in two ways:
 1. Use `@ExcelColumn(columnColumnDataType = ColumnDataType.NUMBER)` to explicitly set the column type
@@ -333,8 +337,11 @@ A: Make sure you've set the appropriate `format` pattern in your `@ExcelColumn` 
 **Q: How can I format numbers with specific patterns?**  
 A: Use the `format` attribute in the `@ExcelColumn` annotation with standard Excel format patterns like `#,##0.00` for numbers or `yyyy-MM-dd` for dates.
 
-**Q: Do I need to specify column indices for all fields?**  
+**Q: Do I need to specify column indices for all fields?**
 A: Only if you're using `ColumnIndexStrategy.USER_DEFINED`. If you use `FIELD_ORDER` strategy, columns will be ordered according to field declaration order in the class.
+
+**Q: Can I reuse an exporter after calling `write()`?**
+A: No. Once `write()` is called, the exporter is closed and cannot be reused. Calling `write()` or `addRows()` after `write()` will throw an `IllegalStateException`. Create a new exporter instance if you need to export again.
 
 ## API Documentation
 

--- a/README.md
+++ b/README.md
@@ -104,18 +104,19 @@ List<Product> products = Arrays.asList(
     new Product(3L, "Headphones", 249.99, LocalDateTime.now())
 );
 
-// 3. Export to Excel
-SXSSFExporter<Product> exporter = SXSSFExporter.builder(Product.class, products)
-    .sheetStrategy(SheetStrategy.MULTI_SHEET) // Optional, MULTI_SHEET is default
-    .maxRows(100)   // Optional, Max row of SpreadsheetVersion.EXCEL2007 is default
-    .sheetName("Products") // Optional, if not specified sheets will be named Sheet0, Sheet1, etc.
-    .build();
+// 3. Export to Excel (recommended: use try-with-resources)
+try (ExcelExporter<Product> exporter = SXSSFExporter.builder(Product.class, products)
+        .sheetStrategy(SheetStrategy.MULTI_SHEET) // Optional, MULTI_SHEET is default
+        .maxRows(100)   // Optional, Max row of SpreadsheetVersion.EXCEL2007 is default
+        .sheetName("Products") // Optional, if not specified sheets will be named Sheet0, Sheet1, etc.
+        .build()) {
 
-// Add more data if needed
-exporter.addRows(moreUsers);
+    // Add more data if needed
+    exporter.addRows(moreProducts);
 
-// Write to file or stream
-exporter.write(outputStream);
+    // Write to file or stream
+    exporter.write(outputStream);
+}  // Resources are automatically cleaned up
 ```
 
 ## Features & Specifications
@@ -322,9 +323,18 @@ Controls how sheets are created when exporting data:
 
 ### Common Issues
 
-**Q: Is this library thread-safe?**  
-A: No. The exporters and underlying Apache POI `Workbook`/`CellStyle` objects are not thread-safe.  
+**Q: Is this library thread-safe?**
+A: No. The exporters and underlying Apache POI `Workbook`/`CellStyle` objects are not thread-safe.
 Create a new exporter per thread/request and do not share exporter instances across threads.
+
+**Q: Should I use try-with-resources with the exporter?**
+A: Yes, it is recommended. The exporter implements `AutoCloseable` and uses temporary files internally (especially `SXSSFWorkbook`). Using try-with-resources ensures proper cleanup even if an exception occurs:
+```java
+try (ExcelExporter<MyData> exporter = SXSSFExporter.builder(MyData.class, data).build()) {
+    exporter.addRows(moreData);
+    exporter.write(outputStream);
+}  // Resources are automatically cleaned up
+```
 
 **Q: Numbers are stored as text in Excel instead of numeric values**  
 A: You can fix this in two ways:
@@ -340,8 +350,8 @@ A: Use the `format` attribute in the `@ExcelColumn` annotation with standard Exc
 **Q: Do I need to specify column indices for all fields?**
 A: Only if you're using `ColumnIndexStrategy.USER_DEFINED`. If you use `FIELD_ORDER` strategy, columns will be ordered according to field declaration order in the class.
 
-**Q: Can I reuse an exporter after calling `write()`?**
-A: No. Once `write()` is called, the exporter is closed and cannot be reused. Calling `write()` or `addRows()` after `write()` will throw an `IllegalStateException`. Create a new exporter instance if you need to export again.
+**Q: Can I reuse an exporter after calling `write()` or `close()`?**
+A: No. Once `write()` or `close()` is called, the exporter is closed and cannot be reused. Calling `write()`, `addRows()`, or `close()` after the exporter is closed will throw an `IllegalStateException` (except `close()` which is idempotent). Create a new exporter instance if you need to export again.
 
 ## API Documentation
 

--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -31,6 +31,9 @@ import org.slf4j.LoggerFactory;
  * <p>This class implements the core functionality while leaving sheet management strategies
  * to be implemented by concrete subclasses.</p>
  *
+ * <p><b>Thread Safety:</b> This class is NOT thread-safe. A single instance should not be
+ * shared across multiple threads. Each thread should create its own exporter instance.</p>
+ *
  * @param <T> The type of data to be handled in the Excel file
  * @param <W> The workbook implementation type
  */
@@ -42,7 +45,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
     protected List<ColumnInfo> columnsMappingInfos;
     protected String dtoTypeName;
 
-    private boolean closed = false;
+    private volatile boolean closed = false;
 
     /**
      * Constructs a new AbstractExcelExporter with the provided workbook instance.
@@ -209,7 +212,6 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
     /**
      * Writes the Excel file content to the specified output stream.
-     * This method ensures proper resource cleanup using try-with-resources.
      * After this method is called, the exporter is closed and cannot be reused.
      *
      * @param stream The output stream to write the Excel file to
@@ -226,9 +228,31 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
         }
         logger.info("Start to write Excel file for DTO class({}.java).", dtoTypeName);
 
-        try (W autoCloseableWb = this.workbook) {
-            autoCloseableWb.write(stream);
+        try {
+            workbook.write(stream);
             logger.info("Successfully wrote Excel file for DTO class({}.java).", dtoTypeName);
+        } finally {
+            close();
+        }
+    }
+
+    /**
+     * Closes the exporter and releases any resources associated with it.
+     * This method is idempotent - calling it multiple times has no additional effect.
+     *
+     * <p>For {@code SXSSFWorkbook}, this also cleans up temporary files created during
+     * the streaming process.</p>
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        try {
+            workbook.close();
+            logger.debug("Workbook closed for DTO class({}.java).", dtoTypeName);
+        } catch (IOException e) {
+            logger.warn("Failed to close workbook for DTO class({}.java).", dtoTypeName, e);
         } finally {
             closed = true;
         }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -42,6 +42,8 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
     protected List<ColumnInfo> columnsMappingInfos;
     protected String dtoTypeName;
 
+    private boolean closed = false;
+
     /**
      * Constructs a new AbstractExcelExporter with the provided workbook instance.
      */
@@ -91,13 +93,26 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
     /**
      * Adds additional rows to the existing Excel file.
+     * This method checks if the exporter is still open before delegating to
+     * the subclass implementation.
+     *
+     * @param data The list of data objects to be added as rows
+     * @throws IllegalStateException if the exporter has already been closed
+     */
+    @Override
+    public final void addRows(List<T> data) {
+        ensureOpen();
+        doAddRows(data);
+    }
+
+    /**
+     * Performs the actual row addition logic.
      * This method must be implemented by subclasses according to their specific
      * sheet management strategy and workbook type.
      *
      * @param data The list of data objects to be added as rows
      */
-    @Override
-    public abstract void addRows(List<T> data);
+    protected abstract void doAddRows(List<T> data);
 
 
 
@@ -181,23 +196,41 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
 
     /**
+     * Ensures that the exporter is still open and can be used.
+     *
+     * @throws IllegalStateException if the exporter has already been closed
+     */
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException(
+                "Exporter is already closed. Cannot reuse after write().");
+        }
+    }
+
+    /**
      * Writes the Excel file content to the specified output stream.
      * This method ensures proper resource cleanup using try-with-resources.
+     * After this method is called, the exporter is closed and cannot be reused.
      *
      * @param stream The output stream to write the Excel file to
      * @throws IOException if an I/O error occurs during writing
-     * @throws NullPointerException if stream is null
+     * @throws IllegalArgumentException if stream is null
+     * @throws IllegalStateException if the exporter has already been closed
      */
     @Override
-    public final void write(OutputStream stream) throws IOException, NullPointerException {
+    public final void write(OutputStream stream) throws IOException {
+        ensureOpen();
+
         if (stream == null) {
-            throw new NullPointerException("Output stream is null.");
+            throw new IllegalArgumentException("Output stream must not be null.");
         }
         logger.info("Start to write Excel file for DTO class({}.java).", dtoTypeName);
 
         try (W autoCloseableWb = this.workbook) {
             autoCloseableWb.write(stream);
             logger.info("Successfully wrote Excel file for DTO class({}.java).", dtoTypeName);
+        } finally {
+            closed = true;
         }
     }
 

--- a/src/main/java/io/github/hee9841/excel/core/exporter/ExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/ExcelExporter.java
@@ -14,12 +14,27 @@ import java.util.List;
  *     <li>Adding rows of data to the Excel file</li>
  * </ul>
  *
+ * <p><b>Resource Management:</b> This interface extends {@link AutoCloseable} to ensure proper
+ * resource cleanup. It is recommended to use try-with-resources when working with exporters,
+ * especially since implementations like {@code SXSSFExporter} create temporary files:</p>
+ * <pre>{@code
+ * try (ExcelExporter<MyData> exporter = SXSSFExporter.builder(MyData.class, data).build()) {
+ *     exporter.addRows(moreData);
+ *     exporter.write(outputStream);
+ * }
+ * }</pre>
+ *
+ * <p><b>Thread Safety:</b> Implementations of this interface are NOT thread-safe.
+ * A single instance should not be shared across multiple threads.
+ * Each thread should create its own exporter instance.</p>
+ *
  * @param <T> The type of data to be handled in the Excel file
  */
-public interface ExcelExporter<T> {
+public interface ExcelExporter<T> extends AutoCloseable {
 
     /**
      * Writes the Excel file content to the specified output stream.
+     * After this method completes, the exporter is closed and cannot be reused.
      *
      * @param stream The output stream to write the Excel file to
      * @throws IOException if an I/O error occurs during writing
@@ -32,4 +47,11 @@ public interface ExcelExporter<T> {
      * @param data The list of data objects to be added as rows
      */
     void addRows(List<T> data);
+
+    /**
+     * Closes the exporter and releases any resources associated with it.
+     * This method is idempotent - calling it multiple times has no additional effect.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -153,7 +153,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
         }
 
         //2. Add Rows
-        addRows(data);
+        doAddRows(data);
 
     }
 
@@ -171,7 +171,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      * @throws ExcelException if ONE_SHEET strategy is used and data exceeds max rows limit
      */
     @Override
-    public void addRows(List<T> data) {
+    protected void doAddRows(List<T> data) {
         // If sheet strategy ONE_SHEET and ata size exceeds the remaining rows, throw Exception
         if (SheetStrategy.isOneSheet(sheetStrategy) &&
             (data.size() > maxRowsIndexPerSheet - currentRowIndex)

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -11,8 +11,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 /**
  * SXSSFExporter is a concrete implementation of {@link AbstractExcelExporter} that provides functionality
  * for exporting data to Excel files. This class uses the SXSSFWorkbook from Apache POI for
- * efficient
- * handling of large datasets by streaming data to disk.
+ * efficient handling of large datasets by streaming data to disk.
  *
  * <p>The SXSSFExporter supports two sheet management strategies:</p>
  * <ul>
@@ -24,6 +23,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
  *
  * @param <T> The type of data to be exported to Excel. The type must be annotated appropriately
  *            for Excel column mapping using the library's annotation system.
+ * @see ExcelExporter
  * @see AbstractExcelExporter
  * @see SXSSFExporterBuilder
  * @see SheetStrategy

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
@@ -16,14 +16,17 @@ import java.util.List;
  *     <li>Sheet Name: null (default sheet names will be used)</li>
  * </ul>
  *
- * <p>Example usage:</p>
- * <pre>
- * SXSSFExporter&lt;MyData&gt; exporter = SXSSFExporter.builder(MyData.class, dataList)
- *     .sheetStrategy(SheetStrategy.ONE_SHEET)
- *     .maxRows(10000)
- *     .sheetName("MySheet")
- *     .build();
- * </pre>
+ * <p>Example usage (recommended with try-with-resources):</p>
+ * <pre>{@code
+ * try (ExcelExporter<MyData> exporter = SXSSFExporter.builder(MyData.class, dataList)
+ *         .sheetStrategy(SheetStrategy.ONE_SHEET)
+ *         .maxRows(10000)
+ *         .sheetName("MySheet")
+ *         .build()) {
+ *     exporter.addRows(moreData);
+ *     exporter.write(outputStream);
+ * }
+ * }</pre>
  *
  * @param <T> The type of data to be exported
  */

--- a/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
@@ -63,6 +63,85 @@ class AbstractExcelExporterTest {
         }
     }
 
+    @DisplayName("write() 호출 후 다시 write()를 호출하면 IllegalStateException을 발생한다.")
+    @Test
+    void writeAfterWriteThrowsException() throws IOException {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            testExporter.write(outputStream);
+        }
+
+        assertThrows(IllegalStateException.class, () -> {
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                testExporter.write(outputStream);
+            }
+        });
+    }
+
+    @DisplayName("write() 호출 후 addRows()를 호출하면 IllegalStateException을 발생한다.")
+    @Test
+    void addRowsAfterWriteThrowsException() throws IOException {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            testExporter.write(outputStream);
+        }
+
+        assertThrows(IllegalStateException.class, () -> testExporter.addRows(List.of()));
+    }
+
+    @DisplayName("close() 호출 후 write()를 호출하면 IllegalStateException을 발생한다.")
+    @Test
+    void writeAfterCloseThrowsException() {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        testExporter.close();
+
+        assertThrows(IllegalStateException.class, () -> {
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                testExporter.write(outputStream);
+            }
+        });
+    }
+
+    @DisplayName("close() 호출 후 addRows()를 호출하면 IllegalStateException을 발생한다.")
+    @Test
+    void addRowsAfterCloseThrowsException() {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        testExporter.close();
+
+        assertThrows(IllegalStateException.class, () -> testExporter.addRows(List.of()));
+    }
+
+    @DisplayName("close()는 여러 번 호출해도 예외가 발생하지 않는다.")
+    @Test
+    void closeIsIdempotent() {
+        Workbook wb = new XSSFWorkbook();
+        TestExporter testExporter = new TestExporter(wb);
+
+        testExporter.close();
+        testExporter.close();
+        testExporter.close();
+        // 예외 없이 정상 종료
+    }
+
+    @DisplayName("try-with-resources로 사용할 수 있다.")
+    @Test
+    void canBeUsedWithTryWithResources() throws IOException {
+        try (TestExporter testExporter = new TestExporter(new XSSFWorkbook());
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            testExporter.write(outputStream);
+            assertThat(outputStream.toByteArray().length).isGreaterThan(0);
+        }
+        // 예외 없이 정상 종료
+    }
+
     private static class TestExporter extends AbstractExcelExporter<Object, Workbook> {
 
         private TestExporter(Workbook workbook) {

--- a/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
@@ -42,13 +42,13 @@ class AbstractExcelExporterTest {
         wb.close();
     }
 
-    @DisplayName("write에 null stream을 전달하면 NPE를 발생한다.")
+    @DisplayName("write에 null stream을 전달하면 IllegalArgumentException을 발생한다.")
     @Test
     void writeThrowsExceptionWhenStreamIsNull() {
         Workbook wb = new XSSFWorkbook();
         TestExporter testExporter = new TestExporter(wb);
 
-        assertThrows(NullPointerException.class, () -> testExporter.write(null));
+        assertThrows(IllegalArgumentException.class, () -> testExporter.write(null));
     }
 
     @DisplayName("워크북이 정상적으로 write 된다.")
@@ -78,7 +78,7 @@ class AbstractExcelExporterTest {
         }
 
         @Override
-        public void addRows(List<Object> data) {
+        protected void doAddRows(List<Object> data) {
         }
     }
 }

--- a/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
@@ -199,7 +199,7 @@ class SXSSFExporterByteOutputStreamTest {
         exporter.write(os);
 
         //then
-        assertEquals(9, memoryAppender.getSize());
+        assertEquals(10, memoryAppender.getSize());
         assertTrue(memoryAppender.isPresent(0,
             "Set sheet strategy and Zip64Mode - strategy: MULTI_SHEET, Zip64Mode: Always.",
             Level.DEBUG));
@@ -211,6 +211,7 @@ class SXSSFExporterByteOutputStreamTest {
         assertTrue(memoryAppender.isPresent(6, "Add rows data - row:2", Level.DEBUG));
         assertTrue(memoryAppender.isPresent(7, "Start to write Excel file", Level.INFO));
         assertTrue(memoryAppender.isPresent(8, "Successfully wrote Excel", Level.INFO));
+        assertTrue(memoryAppender.isPresent(9, "Workbook closed", Level.DEBUG));
     }
 
 
@@ -238,8 +239,9 @@ class SXSSFExporterByteOutputStreamTest {
             assertNull(sheet.getRow(1));
         }
 
-        assertEquals(8, memoryAppender.countEventsForLogger(loggerClassName));
+        assertEquals(9, memoryAppender.countEventsForLogger(loggerClassName));
         assertTrue(memoryAppender.isPresent("Empty data provided", Level.WARN));
+        assertTrue(memoryAppender.isPresent("Workbook closed", Level.DEBUG));
     }
 
     @DisplayName("Sheet 관련 테스트")

--- a/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
@@ -104,6 +104,51 @@ class SXSSFExporterByteOutputStreamTest {
             .contains("The data size exceeds the maximum number of data rows allowed per sheet"));
     }
 
+    @DisplayName("write() 호출 후 addRows()를 호출하면 IllegalStateException이 발생한다.")
+    @Test
+    void addRowsAfterWriteThrowsIllegalStateException() throws IOException {
+        // given
+        List<TestDto> data = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            data.add(new TestDto("test" + (i + 1), i + 1));
+        }
+
+        ExcelExporter<TestDto> exporter = SXSSFExporter.builder(TestDto.class, data)
+            .maxRows(10)
+            .build();
+
+        exporter.write(os);
+
+        // when & then
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> exporter.addRows(data));
+
+        assertTrue(exception.getMessage().contains("already closed"));
+    }
+
+    @DisplayName("write() 호출 후 다시 write()를 호출하면 IllegalStateException이 발생한다.")
+    @Test
+    void writeAfterWriteThrowsIllegalStateException() throws IOException {
+        // given
+        List<TestDto> data = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            data.add(new TestDto("test" + (i + 1), i + 1));
+        }
+
+        ExcelExporter<TestDto> exporter = SXSSFExporter.builder(TestDto.class, data)
+            .maxRows(10)
+            .build();
+
+        exporter.write(os);
+
+        // when & then
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> exporter.write(new ByteArrayOutputStream()));
+
+        assertTrue(exception.getMessage().contains("already closed"));
+    }
+
+
 
     @DisplayName("엑셀 시트 버전의 최대 행을 넘는 max row 값을 설정할 수 없다.")
     @Test


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- ExcelExporter 인터페이스에 AutoCloseable 상속합니다.
- AbstractExcelExporter 에서 close() 오버라이딩하여 객체가 close()되면 workbook의 close()도 보장합니다.
