### PR TITLE
Refactor: Strategy를 Mode로 네이밍 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Java library that helps you work with Excel files easily.
     - [Core Features](#core-features)
     - [Annotations](#annotations)
     - [Custom Cell Styling Options\*\*](#custom-cell-styling-options)
-    - [Strategies](#strategies)
+    - [Modes](#modes)
   - [Annotations](#annotations-1)
     - [@Excel (Class Level)](#excel-class-level)
     - [@ExcelColumn (Field Level)](#excelcolumn-field-level)
@@ -27,11 +27,11 @@ A Java library that helps you work with Excel files easily.
   - [Custom Cell Style](#custom-cell-style)
     - [1. Using Enum classes](#1-using-enum-classes)
     - [2. Using Custom Classes](#2-using-custom-classes)
-  - [Strategies](#strategies-1)
-    - [CellTypeStrategy](#celltypestrategy)
-    - [ColumnIndexStrategy](#columnindexstrategy)
-    - [DataFormatStrategy](#dataformatstrategy)
-    - [SheetStrategy](#sheetstrategy)
+  - [Modes](#modes-1)
+    - [CellTypeMode](#celltypemode)
+    - [ColumnIndexMode](#columnindexmode)
+    - [DataFormatMode](#dataformatmode)
+    - [SheetMode](#sheetmode)
   - [Troubleshooting \& FAQ](#troubleshooting--faq)
     - [Common Issues](#common-issues)
   - [API Documentation](#api-documentation)
@@ -47,7 +47,7 @@ This library is based on Apache POI and helps you to easily map Java DTO (Data T
 - Excel file write operations
 - Annotation-based Excel mapping
 - Cell Styling and Data formatting
-- Flexible extensibility through strategy pattern
+- Flexible extensibility through configurable modes
 
 ## Requirements
 
@@ -73,9 +73,9 @@ Here's a simple example to get you started:
 ```java
 // 1. Define your data model with Excel annotations
 @Excel(
-    columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
-    cellTypeStrategy = CellTypeStrategy.AUTO,
-    dataFormatStrategy = DataFormatStrategy.AUTO_BY_CELL_TYPE
+    columnIndexMode = ColumnIndexMode.USER_DEFINED,
+    cellTypeMode = CellTypeMode.AUTO,
+    dataFormatMode = DataFormatMode.AUTO_BY_CELL_TYPE
 )
 public class Product {
 
@@ -106,7 +106,7 @@ List<Product> products = Arrays.asList(
 
 // 3. Export to Excel (recommended: use try-with-resources)
 try (ExcelExporter<Product> exporter = SXSSFExporter.builder(Product.class, products)
-        .sheetStrategy(SheetStrategy.MULTI_SHEET) // Optional, MULTI_SHEET is default
+        .sheetMode(SheetMode.MULTI_SHEET) // Optional, MULTI_SHEET is default
         .maxRows(100)   // Optional, Max row of SpreadsheetVersion.EXCEL2007 is default
         .sheetName("Products") // Optional, if not specified sheets will be named Sheet0, Sheet1, etc.
         .build()) {
@@ -127,7 +127,7 @@ This library provides several key features and specifications to help you work w
 - Excel file write operations with Apache POI
 - Annotation-based Excel mapping for Java classes
 - Customizable cell styling and data formatting
-- Flexible strategy patterns for column indexing, cell types, and data formats
+- Flexible modes for column indexing, cell types, and data formats
 
 ### Annotations
 - `@Excel` - Class level configuration
@@ -139,11 +139,11 @@ This library provides several key features and specifications to help you work w
 - Custom style classes
 - Pre-defined styles and formats
 
-### Strategies
-- Column indexing strategies
-- Cell type determination strategies 
-- Data format strategies
-- Sheet creation strategies
+### Modes
+- Column indexing modes
+- Cell type determination modes
+- Data format modes
+- Sheet creation modes
 
 See the sections below for detailed information about each feature.
 
@@ -157,9 +157,9 @@ The `@Excel` annotation is applied at the class level and configures global Exce
 
 ```java
 @Excel(
-    columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
-    cellTypeStrategy = CellTypeStrategy.AUTO,
-    dataFormatStrategy = DataFormatStrategy.AUTO_BY_CELL_TYPE,
+    columnIndexMode = ColumnIndexMode.USER_DEFINED,
+    cellTypeMode = CellTypeMode.AUTO,
+    dataFormatMode = DataFormatMode.AUTO_BY_CELL_TYPE,
     headerStyle = @ExcelColumnStyle(cellStyleClass = MyHeaderEnumStyle.class, enumName="GRAY_25"),
     bodyStyle = @ExcelColumnStyle(cellStyleClass = MyBodyStyle.class)
 )
@@ -172,9 +172,9 @@ public class UserDTO {
 
 | Parameter             | Description                             | Default                           |
 |-----------------------|-----------------------------------------|-----------------------------------|
-| `columnIndexStrategy` | Strategy for determining column indices | `ColumnIndexStrategy.FIELD_ORDER` |
-| `cellTypeStrategy`    | Strategy for determining cell types     | `CellTypeStrategy.NONE`           |
-| `dataFormatStrategy`  | Strategy for applying data formats      | `DataFormatStrategy.NONE`         |
+| `columnIndexMode` | Mode for determining column indices | `ColumnIndexMode.FIELD_ORDER` |
+| `cellTypeMode`    | Mode for determining cell types     | `CellTypeMode.NONE`           |
+| `dataFormatMode`  | Mode for applying data formats      | `DataFormatMode.NONE`         |
 | `headerStyle`         | Default style for header cells          | *None*                            |
 | `bodyStyle`           | Default style for body cells            | *None*                            |
 
@@ -203,9 +203,9 @@ private Long id;
 | Parameter              | Description                        | Required?                                          | **Notes**                                                                                                                                                               |
 |------------------------|------------------------------------|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `headerName`           | Column header text                 | Yes                                                |                                                                                                                                                                         |
-| `columnIndex`          | Position of the column             | Only when using `ColumnIndexStrategy.USER_DEFINED` |                                                                                                                                                                         |
-| `columnColumnDataType` | Excel cell type for the column     | No                                                 | **If specified, this overrides any `cellTypeStrategy` setting - even if `cellTypeStrategy` is set to `AUTO`, the explicitly defined type will be used for this column** |
-| `format`               | Format pattern for cell values     | No                                                 | **If specified, this format takes precedence over any automatic formatting from `dataFormatStrategy`, even when `dataFormatStrategy` is set to `AUTO_BY_CELL_TYPE`**    |
+| `columnIndex`          | Position of the column             | Only when using `ColumnIndexMode.USER_DEFINED` |                                                                                                                                                                         |
+| `columnColumnDataType` | Excel cell type for the column     | No                                                 | **If specified, this overrides any `cellTypeMode` setting - even if `cellTypeMode` is set to `AUTO`, the explicitly defined type will be used for this column** |
+| `format`               | Format pattern for cell values     | No                                                 | **If specified, this format takes precedence over any automatic formatting from `dataFormatMode`, even when `dataFormatMode` is set to `AUTO_BY_CELL_TYPE`**    |
 | `headerStyle`          | Style for this column's header     | No                                                 | overrides class-level style                                                                                                                                             |
 | `bodyStyle`            | Style for this column's data cells | No                                                 | overrides class-level style                                                                                                                                             |
 
@@ -287,32 +287,32 @@ public class MyCustomStyle extends CustomExcelCellStyle {
 }
 ```
 
-## Strategies
+## Modes
 
-The library provides several strategies to customize how Excel files are generated.
+The library provides several modes to customize how Excel files are generated.
 
-### CellTypeStrategy
+### CellTypeMode
 
 Controls how cell types are determined:
 
 - `NONE` (default): No automatic cell type determination
 - `AUTO`: Automatically determines cell types based on field types
 
-### ColumnIndexStrategy
+### ColumnIndexMode
 
 Controls how column order is determined:
 
 - `FIELD_ORDER`: Uses the order of field declarations in the class
 - `USER_DEFINED`: Uses explicitly defined column indices from `@ExcelColumn.columnIndex`
 
-### DataFormatStrategy
+### DataFormatMode
 
 Controls how data formatting is applied:
 
 - `NONE` (default): No automatic formatting
 - `AUTO_BY_CELL_TYPE`: Automatically applies formats based on cell types
 
-### SheetStrategy
+### SheetMode
 
 Controls how sheets are created when exporting data:
 
@@ -339,16 +339,16 @@ try (ExcelExporter<MyData> exporter = SXSSFExporter.builder(MyData.class, data).
 **Q: Numbers are stored as text in Excel instead of numeric values**  
 A: You can fix this in two ways:
 1. Use `@ExcelColumn(columnColumnDataType = ColumnDataType.NUMBER)` to explicitly set the column type
-2. Use `CellTypeStrategy.AUTO` in the class-level `@Excel` annotation to automatically detect numeric types
+2. Use `CellTypeMode.AUTO` in the class-level `@Excel` annotation to automatically detect numeric types
 
 **Q: My dates are not formatting correctly in the Excel file**  
-A: Make sure you've set the appropriate `format` pattern in your `@ExcelColumn` annotation(ex.`format = "yyyy-MM-dd HH:mm:ss"`) or use `DataFormatStrategy.AUTO_BY_CELL_TYPE` to apply default date formats.
+A: Make sure you've set the appropriate `format` pattern in your `@ExcelColumn` annotation(ex.`format = "yyyy-MM-dd HH:mm:ss"`) or use `DataFormatMode.AUTO_BY_CELL_TYPE` to apply default date formats.
 
 **Q: How can I format numbers with specific patterns?**  
 A: Use the `format` attribute in the `@ExcelColumn` annotation with standard Excel format patterns like `#,##0.00` for numbers or `yyyy-MM-dd` for dates.
 
 **Q: Do I need to specify column indices for all fields?**
-A: Only if you're using `ColumnIndexStrategy.USER_DEFINED`. If you use `FIELD_ORDER` strategy, columns will be ordered according to field declaration order in the class.
+A: Only if you're using `ColumnIndexMode.USER_DEFINED`. If you use `FIELD_ORDER` mode, columns will be ordered according to field declaration order in the class.
 
 **Q: Can I reuse an exporter after calling `write()` or `close()`?**
 A: No. Once `write()` or `close()` is called, the exporter is closed and cannot be reused. Calling `write()`, `addRows()`, or `close()` after the exporter is closed will throw an `IllegalStateException` (except `close()` which is idempotent). Create a new exporter instance if you need to export again.

--- a/src/main/java/io/github/hee9841/excel/annotation/Excel.java
+++ b/src/main/java/io/github/hee9841/excel/annotation/Excel.java
@@ -1,8 +1,8 @@
 package io.github.hee9841.excel.annotation;
 
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
-import io.github.hee9841.excel.strategy.DataFormatStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
+import io.github.hee9841.excel.mode.DataFormatMode;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,23 +22,23 @@ import java.lang.annotation.Target;
  * <p>Example usage:</p>
  * <pre><code>
  * {@literal @}Excel(
- *     cellTypeStrategy = CellTypeStrategy.AUTO,
- *     columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED
+ *     cellTypeMode = CellTypeMode.AUTO,
+ *     columnIndexMode = ColumnIndexMode.USER_DEFINED
  * )
  * public class UserData {
  *     {@literal @}ExcelColumn(headerName = "User ID", columnIndex = 0)
  *     private Long id;
- *     
+ *
  *     {@literal @}ExcelColumn(headerName = "User Name", columnIndex = 1)
  *     private String name;
- *     
- *     {@literal @}ExcelColumn(headerName = "Registration Date", columnIndex = 2, 
+ *
+ *     {@literal @}ExcelColumn(headerName = "Registration Date", columnIndex = 2,
  *                 format = "yyyy-MM-dd")
  *     private LocalDate registrationDate;
- *     
+ *
  *     // getters and setters...
  * }
- * 
+ *
  * // Usage example:
  * List{@literal <}UserData{@literal >} users = getUserData();
  * SXSSFExporter{@literal <}UserData{@literal >} exporter = SXSSFExporter.builder(UserData.class, users)
@@ -55,28 +55,28 @@ import java.lang.annotation.Target;
 public @interface Excel {
 
     /**
-     * Specifies the strategy for determining column indices in the Excel sheet.
+     * Specifies the mode for determining column indices in the Excel sheet.
      * Default is FIELD_ORDER which uses the order of fields in the class.
      *
-     * @return the column index strategy to use
+     * @return the column index mode to use
      */
-    ColumnIndexStrategy columnIndexStrategy() default ColumnIndexStrategy.FIELD_ORDER;
+    ColumnIndexMode columnIndexMode() default ColumnIndexMode.FIELD_ORDER;
 
     /**
-     * Specifies the strategy for determining cell types in the Excel sheet.
-     * Default is NONE which means no specific cell type strategy is applied.
+     * Specifies the mode for determining cell types in the Excel sheet.
+     * Default is NONE which means no specific cell type mode is applied.
      *
-     * @return the cell type strategy to use
+     * @return the cell type mode to use
      */
-    CellTypeStrategy cellTypeStrategy() default CellTypeStrategy.NONE;
+    CellTypeMode cellTypeMode() default CellTypeMode.NONE;
 
     /**
-     * Specifies the strategy for formatting data in the Excel sheet.
-     * Default is NONE which means no specific data format strategy is applied.
+     * Specifies the mode for formatting data in the Excel sheet.
+     * Default is NONE which means no specific data format mode is applied.
      *
-     * @return the data format strategy to use
+     * @return the data format mode to use
      */
-    DataFormatStrategy dataFormatStrategy() default DataFormatStrategy.NONE;
+    DataFormatMode dataFormatMode() default DataFormatMode.NONE;
 
     /**
      * Specifies the default style to be applied to header cells.

--- a/src/main/java/io/github/hee9841/excel/annotation/ExcelColumn.java
+++ b/src/main/java/io/github/hee9841/excel/annotation/ExcelColumn.java
@@ -30,9 +30,9 @@ public @interface ExcelColumn {
     /**
      * The index of the column in the Excel sheet (starting from 0).
      * If not specified (default -1), the column index will be determined by the
-     * {@link io.github.hee9841.excel.annotation.Excel#columnIndexStrategy()} specified in the @Excel annotation.
-     * When {@link io.github.hee9841.excel.annotation.Excel#columnIndexStrategy()} is
-     * {@link io.github.hee9841.excel.strategy.ColumnIndexStrategy#USER_DEFINED},
+     * {@link io.github.hee9841.excel.annotation.Excel#columnIndexMode()} specified in the @Excel annotation.
+     * When {@link io.github.hee9841.excel.annotation.Excel#columnIndexMode()} is
+     * {@link io.github.hee9841.excel.mode.ColumnIndexMode#USER_DEFINED},
      * this value must be specified.
      *
      * @return the column index (starting from 0), or -1 if not specified
@@ -44,10 +44,10 @@ public @interface ExcelColumn {
      * This determines how data should be interpreted and formatted in the Excel sheet.
      * <p>
      * If specified (not _NONE), this value takes precedence over
-     * the {@link io.github.hee9841.excel.annotation.Excel#cellTypeStrategy()}
+     * the {@link io.github.hee9841.excel.annotation.Excel#cellTypeMode()}
      * is defined in the @Excel annotation. For example,
-     * if {@link io.github.hee9841.excel.annotation.Excel#cellTypeStrategy()}
-     * {@link io.github.hee9841.excel.strategy.CellTypeStrategy#AUTO} but
+     * if {@link io.github.hee9841.excel.annotation.Excel#cellTypeMode()}
+     * {@link io.github.hee9841.excel.mode.CellTypeMode#AUTO} but
      * this columnCellType is specified, the specified type will be used.
      *
      * @return the cell type for the column

--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
  *     <li>Handles cell styling and data type conversion</li>
  * </ul>
  *
- * <p>This class implements the core functionality while leaving sheet management strategies
- * to be implemented by concrete subclasses.</p>
+ * <p>This class implements the core functionality while leaving sheet management
+ * to be implemented by concrete subclasses based on their configured {@link io.github.hee9841.excel.mode.SheetMode}.</p>
  *
  * <p><b>Thread Safety:</b> This class is NOT thread-safe. A single instance should not be
  * shared across multiple threads. Each thread should create its own exporter instance.</p>
@@ -88,7 +88,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
     /**
      * Creates the Excel file with the provided data.
      * This method must be implemented by subclasses to define their specific sheet management
-     * strategy.
+     * based on the configured {@link io.github.hee9841.excel.mode.SheetMode}.
      *
      * @param data The list of data objects to be exported
      */
@@ -110,8 +110,8 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
 
     /**
      * Performs the actual row addition logic.
-     * This method must be implemented by subclasses according to their specific
-     * sheet management strategy and workbook type.
+     * This method must be implemented by subclasses according to their configured
+     * {@link io.github.hee9841.excel.mode.SheetMode} and workbook type.
      *
      * @param data The list of data objects to be added as rows
      */

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -1,7 +1,7 @@
 package io.github.hee9841.excel.core.exporter;
 
 import io.github.hee9841.excel.exception.ExcelException;
-import io.github.hee9841.excel.strategy.SheetStrategy;
+import io.github.hee9841.excel.mode.SheetMode;
 import java.text.MessageFormat;
 import java.util.List;
 import org.apache.poi.ss.SpreadsheetVersion;
@@ -13,7 +13,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
  * for exporting data to Excel files. This class uses the SXSSFWorkbook from Apache POI for
  * efficient handling of large datasets by streaming data to disk.
  *
- * <p>The SXSSFExporter supports two sheet management strategies:</p>
+ * <p>The SXSSFExporter supports two sheet management modes:</p>
  * <ul>
  *     <li>ONE_SHEET - All data is exported to a single sheet (limited by max rows per sheet)</li>
  *     <li>MULTI_SHEET - Data is split across multiple sheets when exceeding max rows per sheet</li>
@@ -26,7 +26,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
  * @see ExcelExporter
  * @see AbstractExcelExporter
  * @see SXSSFExporterBuilder
- * @see SheetStrategy
+ * @see SheetMode
  */
 public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
 
@@ -36,7 +36,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
     private final String sheetNamePrefix;
     private final int maxRowsIndexPerSheet;
 
-    private SheetStrategy sheetStrategy;
+    private SheetMode sheetMode;
 
     private Sheet currentSheet;
     private int currentRowIndex = HEADER_ROW_INDEX;
@@ -51,14 +51,14 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      *
      * @param type            The class type of the data to be exported
      * @param data            The list of data objects to be exported
-     * @param sheetStrategy   The strategy for sheet management (ONE_SHEET or MULTI_SHEET)
+     * @param sheetMode       The mode for sheet management (ONE_SHEET or MULTI_SHEET)
      * @param sheetName       Base name for sheets (null for default names)
      * @param maxRowsPerSheet Maximum number of rows allowed per sheet
      */
     SXSSFExporter(
         Class<T> type,
         List<T> data,
-        SheetStrategy sheetStrategy,
+        SheetMode sheetMode,
         String sheetName,
         int maxRowsPerSheet
     ) {
@@ -68,7 +68,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
         this.maxRowsIndexPerSheet = maxRowsPerSheet - 1;
         this.currentSheetIndex = HEADER_ROW_INDEX;
 
-        setSheetStrategy(sheetStrategy);
+        setSheetMode(sheetMode);
         // Initialize column mapping
         this.initialize(type, data);
 
@@ -90,19 +90,19 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
     }
 
     /**
-     * Sets the sheet strategy for this exporter.
+     * Sets the sheet mode for this exporter.
      *
-     * <p>This method also configures the workbook's Zip64 mode based on the selected strategy.</p>
+     * <p>This method also configures the workbook's Zip64 mode based on the selected mode.</p>
      *
-     * @param strategy The sheet strategy to use (ONE_SHEET or MULTI_SHEET)
+     * @param mode The sheet mode to use (ONE_SHEET or MULTI_SHEET)
      */
-    private void setSheetStrategy(SheetStrategy strategy) {
+    private void setSheetMode(SheetMode mode) {
 
-        this.sheetStrategy = strategy;
-        workbook.setZip64Mode(sheetStrategy.getZip64Mode());
+        this.sheetMode = mode;
+        workbook.setZip64Mode(sheetMode.getZip64Mode());
 
-        logger.debug("Set sheet strategy and Zip64Mode - strategy: {}, Zip64Mode: {}.",
-            strategy.name(), sheetStrategy.getZip64Mode().name());
+        logger.debug("Set sheet mode and Zip64Mode - mode: {}, Zip64Mode: {}.",
+            mode.name(), sheetMode.getZip64Mode().name());
     }
 
 
@@ -110,21 +110,21 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      * Validates the data size against the maximum rows per sheet limit.
      *
      * <p>This method checks if the data size exceeds the maximum allowed rows per sheet
-     * when using ONE_SHEET strategy. If the limit is exceeded, an ExcelException is thrown.</p>
+     * when using ONE_SHEET mode. If the limit is exceeded, an ExcelException is thrown.</p>
      *
      * @param type The class type of the data being validated
      * @param data The list of data objects to be validated
-     * @throws ExcelException if data size exceeds max rows limit with ONE_SHEET strategy
+     * @throws ExcelException if data size exceeds max rows limit with ONE_SHEET mode
      */
     @Override
     protected void validate(Class<?> type, List<T> data) {
-        if (SheetStrategy.isOneSheet(sheetStrategy) && data.size() > maxRowsIndexPerSheet) {
+        if (SheetMode.isOneSheet(sheetMode) && data.size() > maxRowsIndexPerSheet) {
             throw new ExcelException(
                 MessageFormat.format(
                     "The data size exceeds the maximum number of data rows allowed per sheet. "
-                        + "The sheet strategy is set to ONE_SHEET but the data size is larger than "
+                        + "The sheet mode is set to ONE_SHEET but the data size is larger than "
                         + "the maximum data rows per sheet (excluding header) (data size: {0}, maximum data rows: {1}).\n"
-                        + "Please change the sheet strategy to MULTI_SHEET or reduce the data size.",
+                        + "Please change the sheet mode to MULTI_SHEET or reduce the data size.",
                     data.size(), maxRowsIndexPerSheet
                 ), dtoTypeName);
         }
@@ -161,27 +161,27 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
     /**
      * Adds rows to the current sheet for the provided data list.
      *
-     * <p>If the number of rows exceeds the maximum allowed per sheet and the sheet strategy
+     * <p>If the number of rows exceeds the maximum allowed per sheet and the sheet mode
      * is MULTI_SHEET, a new sheet will be created to continue adding rows.</p>
      *
-     * <p>If the sheet strategy is ONE_SHEET and the data size exceeds the remaining rows
+     * <p>If the sheet mode is ONE_SHEET and the data size exceeds the remaining rows
      * in the current sheet, an ExcelException will be thrown.</p>
      *
      * @param data The list of data objects to be added as rows
-     * @throws ExcelException if ONE_SHEET strategy is used and data exceeds max rows limit
+     * @throws ExcelException if ONE_SHEET mode is used and data exceeds max rows limit
      */
     @Override
     protected void doAddRows(List<T> data) {
-        // If sheet strategy ONE_SHEET and ata size exceeds the remaining rows, throw Exception
-        if (SheetStrategy.isOneSheet(sheetStrategy) &&
+        // If sheet mode ONE_SHEET and ata size exceeds the remaining rows, throw Exception
+        if (SheetMode.isOneSheet(sheetMode) &&
             (data.size() > maxRowsIndexPerSheet - currentRowIndex)
         ) {
             throw new ExcelException(
                 MessageFormat.format(
                     "The data size exceeds the remaining data rows in the current sheet. "
-                        + "The sheet strategy is set to ONE_SHEET but the data size is larger than "
+                        + "The sheet mode is set to ONE_SHEET but the data size is larger than "
                         + "the remaining data rows (data size: {0}, remaining data rows: {1}, maximum data rows per sheet (excluding header): {2}).\n"
-                        + "Please change the sheet strategy to MULTI_SHEET or reduce the data size.",
+                        + "Please change the sheet mode to MULTI_SHEET or reduce the data size.",
                     data.size(), (maxRowsIndexPerSheet - currentRowIndex), maxRowsIndexPerSheet),
                 dtoTypeName);
         }

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporterBuilder.java
@@ -1,7 +1,7 @@
 package io.github.hee9841.excel.core.exporter;
 
 import io.github.hee9841.excel.exception.ExcelException;
-import io.github.hee9841.excel.strategy.SheetStrategy;
+import io.github.hee9841.excel.mode.SheetMode;
 import java.util.List;
 
 /**
@@ -11,7 +11,7 @@ import java.util.List;
  *
  * <p>Default configuration:</p>
  * <ul>
- *     <li>Sheet Strategy: MULTI_SHEET</li>
+ *     <li>Sheet Mode: MULTI_SHEET</li>
  *     <li>Max Rows per Sheet: Excel 2007+ maximum - 1</li>
  *     <li>Sheet Name: null (default sheet names will be used)</li>
  * </ul>
@@ -19,7 +19,7 @@ import java.util.List;
  * <p>Example usage (recommended with try-with-resources):</p>
  * <pre>{@code
  * try (ExcelExporter<MyData> exporter = SXSSFExporter.builder(MyData.class, dataList)
- *         .sheetStrategy(SheetStrategy.ONE_SHEET)
+ *         .sheetMode(SheetMode.ONE_SHEET)
  *         .maxRows(10000)
  *         .sheetName("MySheet")
  *         .build()) {
@@ -38,7 +38,7 @@ public class SXSSFExporterBuilder<T> {
     private final int supplyExcelMaxRows;
 
     private int maxRowsPerSheet;
-    private SheetStrategy sheetStrategy;
+    private SheetMode sheetMode;
     private String sheetName;
 
     /**
@@ -57,18 +57,18 @@ public class SXSSFExporterBuilder<T> {
         this.data = data;
         this.supplyExcelMaxRows = supplyExcelMaxRows;
         this.maxRowsPerSheet = supplyExcelMaxRows;
-        this.sheetStrategy = SheetStrategy.MULTI_SHEET;
+        this.sheetMode = SheetMode.MULTI_SHEET;
         this.sheetName = null;
     }
 
     /**
-     * Sets the sheet strategy for the Excel exporter.
+     * Sets the sheet mode for the Excel exporter.
      *
-     * @param sheetStrategy The strategy to use for sheet management (ONE_SHEET or MULTI_SHEET)
+     * @param sheetMode The mode to use for sheet management (ONE_SHEET or MULTI_SHEET)
      * @return This builder instance for method chaining
      */
-    public SXSSFExporterBuilder<T> sheetStrategy(SheetStrategy sheetStrategy) {
-        this.sheetStrategy = sheetStrategy;
+    public SXSSFExporterBuilder<T> sheetMode(SheetMode sheetMode) {
+        this.sheetMode = sheetMode;
         return this;
     }
 
@@ -116,7 +116,7 @@ public class SXSSFExporterBuilder<T> {
         return new SXSSFExporter<T>(
             this.type,
             this.data,
-            this.sheetStrategy,
+            this.sheetMode,
             this.sheetName,
             this.maxRowsPerSheet
         );

--- a/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfoMapper.java
+++ b/src/main/java/io/github/hee9841/excel/core/meta/ColumnInfoMapper.java
@@ -10,9 +10,9 @@ import io.github.hee9841.excel.exception.ExcelException;
 import io.github.hee9841.excel.exception.ExcelStyleException;
 import io.github.hee9841.excel.format.CellFormats;
 import io.github.hee9841.excel.format.ExcelDataFormatter;
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
-import io.github.hee9841.excel.strategy.DataFormatStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
+import io.github.hee9841.excel.mode.DataFormatMode;
 import io.github.hee9841.excel.style.ExcelCellStyle;
 import io.github.hee9841.excel.style.NoCellStyle;
 import java.lang.reflect.Field;
@@ -67,17 +67,17 @@ public class ColumnInfoMapper {
     private final CellStyle defaultBodyStyle;
 
     /**
-     * Strategy for determining column indices
+     * Mode for determining column indices
      */
-    private ColumnIndexStrategy columnIndexStrategy;
+    private ColumnIndexMode columnIndexMode;
     /**
-     * Strategy for determining cell types
+     * Mode for determining cell types
      */
-    private CellTypeStrategy cellTypeStrategy;
+    private CellTypeMode cellTypeMode;
     /**
-     * Strategy for determining data formats
+     * Mode for determining data formats
      */
-    private DataFormatStrategy dataFormatStrategy;
+    private DataFormatMode dataFormatMode;
 
 
     private ColumnInfoMapper(Class<?> type, Workbook wb) {
@@ -117,7 +117,7 @@ public class ColumnInfoMapper {
 
     /**
      * Parses the {@link Excel} annotation on the class to determine global settings.
-     * Sets up the column index strategy, cell type strategy, and data format strategy.
+     * Sets up the column index mode, cell type mode, and data format mode.
      * Also applies default styles for headers and bodies.
      *
      * @throws ExcelException If the {@link Excel} annotation is missing
@@ -126,9 +126,9 @@ public class ColumnInfoMapper {
         validateExcelAnnotation(type);
 
         Excel excel = type.getAnnotation(Excel.class);
-        columnIndexStrategy = excel.columnIndexStrategy();
-        cellTypeStrategy = excel.cellTypeStrategy();
-        dataFormatStrategy = excel.dataFormatStrategy();
+        columnIndexMode = excel.columnIndexMode();
+        cellTypeMode = excel.cellTypeMode();
+        dataFormatMode = excel.dataFormatMode();
 
         //set default style
         getExcelCellStyle(excel.defaultHeaderStyle()).apply(defaultHeaderStyle);
@@ -177,7 +177,7 @@ public class ColumnInfoMapper {
             field.setAccessible(true);
 
             //set column index value
-            int columnIndex = columnIndexStrategy.isFieldOrder()
+            int columnIndex = columnIndexMode.isFieldOrder()
                 ? autoColumnIndexCnt++
                 : excelColumn.columnIndex();
             validateColumnIndex(indexLookup, columnIndex, field.getName());
@@ -238,8 +238,8 @@ public class ColumnInfoMapper {
         if (columnIndex < 0) {
             throw new ExcelException(String.format(
                 "Invalid column index : The column index of '%s' field is negative or "
-                    + "column index value was not specified when column index strategy is USER_DEFINED.\n"
-                    + "Please Change index value to non-negative or Use 'FIELD_ORDER' strategy."
+                    + "column index value was not specified when column index mode is USER_DEFINED.\n"
+                    + "Please Change index value to non-negative or Use 'FIELD_ORDER' mode."
                 , fieldName),
                 type.getName()
             );
@@ -296,29 +296,29 @@ public class ColumnInfoMapper {
     /**
      * Creates a {@link ExcelDataFormatter} for a cell based on the format pattern and
      * {@link ColumnDataType}.
-     * Applies automatic formatting if the {@link DataFormatStrategy} is
-     * {@link DataFormatStrategy#AUTO_BY_CELL_TYPE} by {@link ColumnDataType}.
+     * Applies automatic formatting if the {@link DataFormatMode} is
+     * {@link DataFormatMode#AUTO_BY_CELL_TYPE} by {@link ColumnDataType}.
      *
      * @param pattern        The format pattern specified in the annotation
      * @param columnDataType The {@link ColumnDataType}
      * @return An {@link ExcelDataFormatter} for the cell
      */
     private ExcelDataFormatter getDataFormatter(String pattern, ColumnDataType columnDataType) {
-        // When dataFormatStrategy is "AUTO" and format pattern is "isNone"(empty or null),
+        // When dataFormatMode is "AUTO" and format pattern is "isNone"(empty or null),
         // apply auto format pattern.
-        if ((dataFormatStrategy.isAutoByColumnDataType() && CellFormats.isNone(pattern))) {
+        if ((dataFormatMode.isAutoByColumnDataType() && CellFormats.isNone(pattern))) {
             pattern = columnDataType.getDataFormatPattern();
         }
 
-        // When dataFormatStrategy is "AUTO" and format pattern is not "isNone"
-        // or dataFormatStrategy is "NONE"(format pattern is "isNone" or any value),
+        // When dataFormatMode is "AUTO" and format pattern is not "isNone"
+        // or dataFormatMode is "NONE"(format pattern is "isNone" or any value),
         // apply parameter "pattern" value.
         return ExcelDataFormatter.of(wb.createDataFormat(), pattern);
     }
 
     /**
      * Determines the appropriate {@link ColumnDataType} for a field based on the column cell type
-     * and the {@link CellTypeStrategy}.
+     * and the {@link CellTypeMode}.
      *
      * @param columnColumnDataType The {@link ColumnDataType} specified in the annotation
      * @param fieldType            The type of the field
@@ -330,10 +330,10 @@ public class ColumnInfoMapper {
      */
     private ColumnDataType getColumnDataType(ColumnDataType columnColumnDataType,
         Class<?> fieldType, String fieldName) {
-        // When cell type strategy is AUTO and column cell type is not specified
+        // When cell type mode is AUTO and column cell type is not specified
         // or when column cell type is AUTO,
         // the column's cell type is automatically determined based on the field type.
-        if ((cellTypeStrategy.isAuto() && columnColumnDataType.isNone())
+        if ((cellTypeMode.isAuto() && columnColumnDataType.isNone())
             || columnColumnDataType.isAuto()) {
             return ColumnDataType.from(fieldType);
         }

--- a/src/main/java/io/github/hee9841/excel/mode/CellTypeMode.java
+++ b/src/main/java/io/github/hee9841/excel/mode/CellTypeMode.java
@@ -1,39 +1,39 @@
-package io.github.hee9841.excel.strategy;
+package io.github.hee9841.excel.mode;
 
 
 /**
- * Strategy enum that determines how cell types are assigned in Excel sheets.
+ * Mode enum that determines how cell types are assigned in Excel sheets.
  * <p>
- * This enum defines strategies for determining the data type and format of cells
+ * This enum defines modes for determining the data type and format of cells
  * when exporting data to Excel. It works in conjunction with the
  * {@link io.github.hee9841.excel.core.meta.ColumnDataType} enum to control how different Java types
  * are represented in Excel.
  * </p>
- * The available strategies are:
+ * The available modes are:
  * <ul>
  *   <li>{@code NONE}: Cell types are not applied.</li>
  *   <li>{@code AUTO}: Cell types are automatically determined based on the Java type of each field.</li>
  * </ul>
  * <p>
- * This strategy is typically configured at the class level using the
- * {@link io.github.hee9841.excel.annotation.Excel#cellTypeStrategy()} annotation parameter and
+ * This mode is typically configured at the class level using the
+ * {@link io.github.hee9841.excel.annotation.Excel#cellTypeMode()} annotation parameter and
  * can be overridden at the column level using
  * {@link io.github.hee9841.excel.annotation.ExcelColumn#columnCellType()}.
  * </p>
- * When used with {@link DataFormatStrategy#AUTO_BY_CELL_TYPE}, it also affects how data formatting
+ * When used with {@link DataFormatMode#AUTO_BY_CELL_TYPE}, it also affects how data formatting
  * is applied to cells.
  *
- * @see io.github.hee9841.excel.annotation.Excel#cellTypeStrategy()
+ * @see io.github.hee9841.excel.annotation.Excel#cellTypeMode()
  * @see io.github.hee9841.excel.annotation.ExcelColumn#columnCellType()
  * @see io.github.hee9841.excel.core.meta.ColumnDataType
  * @see io.github.hee9841.excel.core.meta.ColumnInfoMapper
- * @see DataFormatStrategy
+ * @see DataFormatMode
  */
-public enum CellTypeStrategy {
+public enum CellTypeMode {
     /**
-     * Strategy that does not apply any cell type.
+     * Mode that does not apply any cell type.
      * <p>
-     * With this strategy, you can explicitly specify the cell type for each column
+     * With this mode, you can explicitly specify the cell type for each column
      * using the {@link io.github.hee9841.excel.annotation.ExcelColumn#columnCellType()} parameter
      * or if not specified, cell type will be {@link io.github.hee9841.excel.core.meta.ColumnDataType#_NONE}.
      * </p>
@@ -41,9 +41,9 @@ public enum CellTypeStrategy {
     NONE,
 
     /**
-     * Strategy that automatically determines cell types based on field types.
+     * Mode that automatically determines cell types based on field types.
      * <p>
-     * With this strategy, the cell type is automatically determined based on the Java type
+     * With this mode, the cell type is automatically determined based on the Java type
      * of each field. This simplifies configuration but may not always choose the optimal
      * representation, especially for complex types or when specific formatting is required.
      * </p>

--- a/src/main/java/io/github/hee9841/excel/mode/ColumnIndexMode.java
+++ b/src/main/java/io/github/hee9841/excel/mode/ColumnIndexMode.java
@@ -1,13 +1,13 @@
-package io.github.hee9841.excel.strategy;
+package io.github.hee9841.excel.mode;
 
 /**
- * Strategy enum that determines how column indices are assigned in Excel sheets.
+ * Mode enum that determines how column indices are assigned in Excel sheets.
  * <p>
- * This enum defines strategies for determining the order and position of columns
+ * This enum defines modes for determining the order and position of columns
  * when exporting data to Excel. It controls whether column indices are determined
  * automatically based on field declaration order or explicitly defined by the user.
  * <p>
- * The available strategies are:
+ * The available modes are:
  * <ul>
  *   <li>{@code FIELD_ORDER}: Column indices are assigned based on the order that fields
  *       are declared in the class. This is the simplest approach and requires no
@@ -17,18 +17,18 @@ package io.github.hee9841.excel.strategy;
  *       This gives precise control over column positioning.</li>
  * </ul>
  * <p>
- * This strategy is typically configured at the class level using the
- * {@link io.github.hee9841.excel.annotation.Excel#columnIndexStrategy()} annotation parameter.
+ * This mode is typically configured at the class level using the
+ * {@link io.github.hee9841.excel.annotation.Excel#columnIndexMode()} annotation parameter.
  *
- * @see io.github.hee9841.excel.annotation.Excel#columnIndexStrategy()
+ * @see io.github.hee9841.excel.annotation.Excel#columnIndexMode()
  * @see io.github.hee9841.excel.annotation.ExcelColumn#columnIndex()
  * @see io.github.hee9841.excel.core.meta.ColumnInfoMapper
  */
-public enum ColumnIndexStrategy {
+public enum ColumnIndexMode {
     /**
-     * Strategy that assigns column indices based on the order of field declarations.
+     * Mode that assigns column indices based on the order of field declarations.
      * <p>
-     * When this strategy is used, the
+     * When this mode is used, the
      * {@link io.github.hee9841.excel.annotation.ExcelColumn#columnIndex()}
      * parameter is ignored, and columns appear in the Excel sheet in the same order
      * that fields are declared in the Java class.
@@ -36,9 +36,9 @@ public enum ColumnIndexStrategy {
     FIELD_ORDER,
 
     /**
-     * Strategy that assigns column indices based on explicit user definition.
+     * Mode that assigns column indices based on explicit user definition.
      * <p>
-     * When this strategy is used, the
+     * When this mode is used, the
      * {@link io.github.hee9841.excel.annotation.ExcelColumn#columnIndex()}
      * parameter must be specified for each column and determines its column index in the Excel
      * sheet.

--- a/src/main/java/io/github/hee9841/excel/mode/DataFormatMode.java
+++ b/src/main/java/io/github/hee9841/excel/mode/DataFormatMode.java
@@ -1,36 +1,36 @@
-package io.github.hee9841.excel.strategy;
+package io.github.hee9841.excel.mode;
 
 /**
- * Strategy enum that determines how data formatting is applied to Excel cells.
+ * Mode enum that determines how data formatting is applied to Excel cells.
  * <p>
- * This enum defines strategies for controlling how cell formatting patterns are determined and
+ * This enum defines modes for controlling how cell formatting patterns are determined and
  * applied during
  * Excel export operations. It works in conjunction with the {@link io.github.hee9841.excel.core.meta.ColumnDataType}
  * to apply appropriate formatting to different types of data.
  * <p>
- * The available strategies are:
+ * The available modes are:
  * <ul>
  *   <li>{@code NONE}: No automatic formatting is applied. Formatting must be explicitly specified
  *       in the {@link io.github.hee9841.excel.annotation.ExcelColumn} annotation.</li>
  *   <li>{@code AUTO_BY_CELL_TYPE}: Automatic formatting is applied based on the {@link io.github.hee9841.excel.core.meta.ColumnDataType}, but only when the
- *       {@link io.github.hee9841.excel.annotation.ExcelColumn#columnCellType()} is explicitly set or determined by the {@link CellTypeStrategy} (not when it's NONE).
+ *       {@link io.github.hee9841.excel.annotation.ExcelColumn#columnCellType()} is explicitly set or determined by the {@link CellTypeMode} (not when it's NONE).
  *       If user specified the {@code format} parameter in the {@link io.github.hee9841.excel.annotation.ExcelColumn} annotation, it will take precedence over the automatic format.
  *   </li>
  * </ul>
  * <p>
- * This strategy is typically configured at the class level using the {@link io.github.hee9841.excel.annotation.Excel}
+ * This mode is typically configured at the class level using the {@link io.github.hee9841.excel.annotation.Excel}
  * annotation and affects all columns unless overridden at the column level.
  *
- * @see io.github.hee9841.excel.annotation.Excel#dataFormatStrategy()
+ * @see io.github.hee9841.excel.annotation.Excel#dataFormatMode()
  * @see io.github.hee9841.excel.core.meta.ColumnDataType
  * @see io.github.hee9841.excel.format.ExcelDataFormatter
  * @see io.github.hee9841.excel.format.CellFormats
  */
-public enum DataFormatStrategy {
+public enum DataFormatMode {
     /**
      * No automatic formatting is applied.
      * <p>
-     * With this strategy, the format pattern must be explicitly specified in the
+     * With this mode, the format pattern must be explicitly specified in the
      * {@link io.github.hee9841.excel.annotation.ExcelColumn} annotation using the
      * {@code format} parameter. If no format is specified, the default
      * format({@link io.github.hee9841.excel.format.CellFormats#_NONE}) for
@@ -41,8 +41,8 @@ public enum DataFormatStrategy {
     /**
      * Automatic formatting is applied based on the cell type.
      * <p>
-     * This strategy only applies when the cell type is explicitly set (not NONE) or
-     * determined by the {@link CellTypeStrategy} (when set to AUTO). It uses the format
+     * This mode only applies when the cell type is explicitly set (not NONE) or
+     * determined by the {@link CellTypeMode} (when set to AUTO). It uses the format
      * pattern defined for each {@link io.github.hee9841.excel.core.meta.ColumnDataType} to format
      * the cell appropriately for its data type.
      * <p>

--- a/src/main/java/io/github/hee9841/excel/mode/SheetMode.java
+++ b/src/main/java/io/github/hee9841/excel/mode/SheetMode.java
@@ -1,4 +1,4 @@
-package io.github.hee9841.excel.strategy;
+package io.github.hee9841.excel.mode;
 
 import static org.apache.commons.compress.archivers.zip.Zip64Mode.Always;
 import static org.apache.commons.compress.archivers.zip.Zip64Mode.AsNeeded;
@@ -8,10 +8,10 @@ import java.util.Objects;
 import org.apache.commons.compress.archivers.zip.Zip64Mode;
 
 /**
- * Strategy enum that determines how Excel sheets are created and managed during export operations.
+ * Mode enum that determines how Excel sheets are created and managed during export operations.
  * <p>
  * This enum controls whether data is exported to a single sheet or multiple sheets, which affects
- * the Zip64 mode used when creating large Excel files. Each strategy is associated with a specific
+ * the Zip64 mode used when creating large Excel files. Each mode is associated with a specific
  * {@link Zip64Mode} that optimizes file handling based on the expected data volume.
  * <p>
  * The Zip64 mode affects how Apache POI handles large Excel files:
@@ -24,16 +24,16 @@ import org.apache.commons.compress.archivers.zip.Zip64Mode;
  * @see org.apache.commons.compress.archivers.zip.Zip64Mode
  * @see io.github.hee9841.excel.annotation.Excel
  */
-public enum SheetStrategy {
+public enum SheetMode {
     /**
-     * Strategy for exporting data to a single sheet.
+     * Mode for exporting data to a single sheet.
      * Uses the {@code AsNeeded} Zip64 mode which only enables Zip64 extensions when necessary.
      * This is more efficient for smaller datasets that fit within a single sheet.
      */
     ONE_SHEET(AsNeeded),
 
     /**
-     * Strategy for exporting data across multiple sheets.
+     * Mode for exporting data across multiple sheets.
      * Uses the {@code Always} Zip64 mode which always enables Zip64 extensions.
      * This is recommended for larger datasets that need to be split across multiple sheets.
      */
@@ -43,16 +43,16 @@ public enum SheetStrategy {
 
     private final Zip64Mode zip64Mode;
 
-    SheetStrategy(Zip64Mode zip64Mode) {
+    SheetMode(Zip64Mode zip64Mode) {
         this.zip64Mode = zip64Mode;
     }
 
-    public static boolean isOneSheet(SheetStrategy sheetStrategy) {
-        return Objects.equals(sheetStrategy, ONE_SHEET);
+    public static boolean isOneSheet(SheetMode sheetMode) {
+        return Objects.equals(sheetMode, ONE_SHEET);
     }
 
-    public static boolean isMultiSheet(SheetStrategy sheetStrategy) {
-        return Objects.equals(sheetStrategy, MULTI_SHEET);
+    public static boolean isMultiSheet(SheetMode sheetMode) {
+        return Objects.equals(sheetMode, MULTI_SHEET);
     }
 
     public Zip64Mode getZip64Mode() {

--- a/src/main/java/io/github/hee9841/excel/style/align/ExcelAlign.java
+++ b/src/main/java/io/github/hee9841/excel/style/align/ExcelAlign.java
@@ -4,7 +4,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 
 /**
  * Interface defining alignment behavior for Excel cells.
- * Implementations of this interface provide different strategies for
+ * Implementations of this interface provide different approaches for
  * applying horizontal and vertical alignment to Excel cell styles.
  *
  * @see io.github.hee9841.excel.style.align.DefaultExcelAlign

--- a/src/main/java/io/github/hee9841/excel/style/border/ExcelBorder.java
+++ b/src/main/java/io/github/hee9841/excel/style/border/ExcelBorder.java
@@ -4,7 +4,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 
 /**
  * Interface defining border behavior for Excel cells.
- * Implementations of this interface provide different strategies for
+ * Implementations of this interface provide different approaches for
  * applying border styles to Excel cell styles.
  *
  * @see io.github.hee9841.excel.style.border.DefaultExcelBorder

--- a/src/main/java/io/github/hee9841/excel/style/color/ExcelColor.java
+++ b/src/main/java/io/github/hee9841/excel/style/color/ExcelColor.java
@@ -4,7 +4,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 
 /**
  * Interface defining color behavior for Excel cell backgrounds.
- * Implementations of this interface provide different strategies for
+ * Implementations of this interface provide different approaches for
  * applying background colors to Excel cell styles.
  *
  * @see PaletteExcelColor

--- a/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.github.hee9841.excel.annotation.Excel;
 import io.github.hee9841.excel.annotation.ExcelColumn;
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -58,8 +58,8 @@ class ExcelExporterTest {
     }
 
     @Excel(
-        columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
-        cellTypeStrategy = CellTypeStrategy.AUTO
+        columnIndexMode = ColumnIndexMode.USER_DEFINED,
+        cellTypeMode = CellTypeMode.AUTO
     )
     static class TestDto {
         @ExcelColumn(headerName = "name", columnIndex = 0)

--- a/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/SXSSFExporterByteOutputStreamTest.java
@@ -16,10 +16,10 @@ import io.github.hee9841.excel.example.dto.TypeAutoDto;
 import io.github.hee9841.excel.example.style.EnumCellStyleExample;
 import io.github.hee9841.excel.exception.ExcelException;
 import io.github.hee9841.excel.format.CellFormats;
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
-import io.github.hee9841.excel.strategy.DataFormatStrategy;
-import io.github.hee9841.excel.strategy.SheetStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
+import io.github.hee9841.excel.mode.DataFormatMode;
+import io.github.hee9841.excel.mode.SheetMode;
 import io.github.hee9841.excel.style.CustomExcelCellStyle;
 import io.github.hee9841.excel.style.align.DefaultExcelAlign;
 import io.github.hee9841.excel.style.color.ColorPalette;
@@ -94,8 +94,8 @@ class SXSSFExporterByteOutputStreamTest {
         ExcelException exception = assertThrows(ExcelException.class, () ->
             SXSSFExporter.builder(TestDto.class, data)
                 .maxRows(maxRows)
-                .sheetStrategy(
-                    SheetStrategy.ONE_SHEET) // Force ONE_SHEET strategy to ensure exception is thrown
+                .sheetMode(
+                    SheetMode.ONE_SHEET) // Force ONE_SHEET mode to ensure exception is thrown
                 .build()
         );
 
@@ -201,7 +201,7 @@ class SXSSFExporterByteOutputStreamTest {
         //then
         assertEquals(10, memoryAppender.getSize());
         assertTrue(memoryAppender.isPresent(0,
-            "Set sheet strategy and Zip64Mode - strategy: MULTI_SHEET, Zip64Mode: Always.",
+            "Set sheet mode and Zip64Mode - mode: MULTI_SHEET, Zip64Mode: Always.",
             Level.DEBUG));
         assertTrue(memoryAppender.isPresent(1, "Initializing", Level.INFO));
         assertTrue(memoryAppender.isPresent(2, "Mapping", Level.DEBUG));
@@ -283,7 +283,7 @@ class SXSSFExporterByteOutputStreamTest {
 
             assertTrue(memoryAppender
                 .isPresent(
-                    "Set sheet strategy and Zip64Mode - strategy: MULTI_SHEET, Zip64Mode: Always",
+                    "Set sheet mode and Zip64Mode - mode: MULTI_SHEET, Zip64Mode: Always",
                     Level.DEBUG)
             );
             assertEquals(rowCnt, memoryAppender.search("Add rows data", Level.DEBUG).size());
@@ -304,7 +304,7 @@ class SXSSFExporterByteOutputStreamTest {
             ExcelException exception = assertThrows(ExcelException.class,
                 () -> SXSSFExporter.builder(TestDto.class, testData)
                     .maxRows(10)
-                    .sheetStrategy(SheetStrategy.ONE_SHEET)
+                    .sheetMode(SheetMode.ONE_SHEET)
                     .build()
             );
 
@@ -316,7 +316,7 @@ class SXSSFExporterByteOutputStreamTest {
             assertEquals(2, memoryAppender.getSize());
             assertTrue(memoryAppender.isPresent("Initializing", Level.INFO));
             assertTrue(memoryAppender.isPresent(
-                "Set sheet strategy and Zip64Mode - strategy: ONE_SHEET, Zip64Mode: AsNeeded.",
+                "Set sheet mode and Zip64Mode - mode: ONE_SHEET, Zip64Mode: AsNeeded.",
                 Level.DEBUG));
         }
 
@@ -360,7 +360,7 @@ class SXSSFExporterByteOutputStreamTest {
 
         SXSSFExporter<TestDto> exporter = SXSSFExporter.builder(TestDto.class, initialData)
             .maxRows(5)
-            .sheetStrategy(SheetStrategy.ONE_SHEET)
+            .sheetMode(SheetMode.ONE_SHEET)
             .build();
 
         List<TestDto> additionalData = new ArrayList<>();
@@ -564,14 +564,14 @@ class SXSSFExporterByteOutputStreamTest {
 
 
     @Excel(
-        columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
+        columnIndexMode = ColumnIndexMode.USER_DEFINED,
         defaultHeaderStyle = @ExcelColumnStyle(
             cellStyleClass = EnumCellStyleExample.class,
             enumName = "GREY_25_PERCENT_CENTER_CENTER_ALL_BORDER_THICK"
         ),
         defaultBodyStyle = @ExcelColumnStyle(cellStyleClass = DefaultBodyStyle.class),
-        cellTypeStrategy = CellTypeStrategy.AUTO,
-        dataFormatStrategy = DataFormatStrategy.AUTO_BY_CELL_TYPE
+        cellTypeMode = CellTypeMode.AUTO,
+        dataFormatMode = DataFormatMode.AUTO_BY_CELL_TYPE
     )
     static class TestDto {
 

--- a/src/test/java/io/github/hee9841/excel/core/meta/ColumnInfoMapperTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/meta/ColumnInfoMapperTest.java
@@ -1,6 +1,6 @@
 package io.github.hee9841.excel.core.meta;
 
-import static io.github.hee9841.excel.strategy.ColumnIndexStrategy.USER_DEFINED;
+import static io.github.hee9841.excel.mode.ColumnIndexMode.USER_DEFINED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,9 +10,9 @@ import io.github.hee9841.excel.annotation.ExcelColumn;
 import io.github.hee9841.excel.example.dto.TypeAutoDto;
 import io.github.hee9841.excel.exception.ExcelException;
 import io.github.hee9841.excel.format.CellFormats;
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
-import io.github.hee9841.excel.strategy.DataFormatStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
+import io.github.hee9841.excel.mode.DataFormatMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -81,7 +81,7 @@ class ColumnInfoMapperTest {
     @Nested
     class ColumnIndexMappingTest {
 
-        @DisplayName("FIELD_ORDER 전략일 경우, 필드 순서대로 맵핑된다.")
+        @DisplayName("FIELD_ORDER 모드일 경우, 필드 순서대로 맵핑된다.")
         @Test
         void fieldOrder_MappedByFieldOrder() {
             //given
@@ -110,11 +110,11 @@ class ColumnInfoMapperTest {
             assertEquals("secondField", secondCol.getFieldName());
         }
 
-        @DisplayName("USER_DEFINED 전략일 경우, 지정한 Index값으로 맵핑된다.")
+        @DisplayName("USER_DEFINED 모드일 경우, 지정한 Index값으로 맵핑된다.")
         @Test
         void userDefined_MappedByUserDefined() {
             //given
-            @Excel(columnIndexStrategy = USER_DEFINED)
+            @Excel(columnIndexMode = USER_DEFINED)
             class TestExcelDto {
 
                 @ExcelColumn(headerName = "firstHeader", columnIndex = 5)
@@ -140,11 +140,11 @@ class ColumnInfoMapperTest {
         }
 
 
-        @DisplayName("FIELD_ORDER 전략일 경우, 지정한 columnIndex를 무시")
+        @DisplayName("FIELD_ORDER 모드일 경우, 지정한 columnIndex를 무시")
         @Test
         void fieldOrder_Ignore_columnIndexByUserDefined() {
             //given
-            @Excel(columnIndexStrategy = ColumnIndexStrategy.FIELD_ORDER)
+            @Excel(columnIndexMode = ColumnIndexMode.FIELD_ORDER)
             class TestExcelDto {
 
                 @ExcelColumn(headerName = "일", columnIndex = 3)
@@ -172,11 +172,11 @@ class ColumnInfoMapperTest {
         class ColumnIdxMappingException {
 
 
-            @DisplayName("USER_DEFINED 전략일 경우, columnIndex를 지정하지 않는 경우 예외 발생")
+            @DisplayName("USER_DEFINED 모드일 경우, columnIndex를 지정하지 않는 경우 예외 발생")
             @Test
             void userDefined_AndNotSetColumnIndex_Failed_Mapping() {
                 //given
-                @Excel(columnIndexStrategy = USER_DEFINED)
+                @Excel(columnIndexMode = USER_DEFINED)
                 class TestExcelDto {
 
                     @ExcelColumn(headerName = "일")
@@ -198,11 +198,11 @@ class ColumnInfoMapperTest {
             }
 
 
-            @DisplayName("USER_DEFINED 전략일 경우, columnIndex값이 음수일 때 예외 발생")
+            @DisplayName("USER_DEFINED 모드일 경우, columnIndex값이 음수일 때 예외 발생")
             @Test
             void userDefined_AndColumnIndexNegative_Failed_Mapping() {
                 //given
-                @Excel(columnIndexStrategy = USER_DEFINED)
+                @Excel(columnIndexMode = USER_DEFINED)
                 class TestExcelDto {
 
                     @ExcelColumn(headerName = "일", columnIndex = -5)
@@ -224,11 +224,11 @@ class ColumnInfoMapperTest {
 
             }
 
-            @DisplayName("USER_DEFINED 전략일 경우, columnIndex 값이 중복 되면 예외 발생")
+            @DisplayName("USER_DEFINED 모드일 경우, columnIndex 값이 중복 되면 예외 발생")
             @Test
             void userDefined_DuplicateColumnIndex() {
                 //given
-                @Excel(columnIndexStrategy = USER_DEFINED)
+                @Excel(columnIndexMode = USER_DEFINED)
                 class TestExcelDto {
 
                     @ExcelColumn(headerName = "first", columnIndex = 3)
@@ -287,7 +287,7 @@ class ColumnInfoMapperTest {
 
         @DisplayName("AUTO: 필드 타입에 따라 자동으로 또는 사용자가 지정한 타입에 맞게 맵핑된다.")
         @Test
-        void cellTypeStrategyIsAuto_applyAutoType() {
+        void cellTypeModeIsAuto_applyAutoType() {
             //given && when
             List<ColumnInfo> columnInfos = ColumnInfoMapper
                 .of(TypeAutoDto.class, wb).map();
@@ -321,9 +321,9 @@ class ColumnInfoMapperTest {
             }
         }
 
-        @DisplayName("cellType 전략과 columnCellType을 지정하지 않았을 경우, None type으로 지정한다.")
+        @DisplayName("cellType 모드와 columnCellType을 지정하지 않았을 경우, None type으로 지정한다.")
         @Test
-        void cellTypeStrategyAndColumnType_IsNone_applyNoneType() {
+        void cellTypeModeAndColumnType_IsNone_applyNoneType() {
             //given
             @Excel
             class TestDto {
@@ -345,9 +345,9 @@ class ColumnInfoMapperTest {
     @Nested
     class DataFormatMappingTest {
 
-        @DisplayName("dataFormat전략이 None: 각 컬럼에 format을 지정 안하면 none으로, 지정한면 지정한 패턴으로 적용된다.")
+        @DisplayName("dataFormat모드가 None: 각 컬럼에 format을 지정 안하면 none으로, 지정한면 지정한 패턴으로 적용된다.")
         @Test
-        void strategyIsNone_appliedByPattern() {
+        void modeIsNone_appliedByPattern() {
             //given
             @Excel
             class TestDto {
@@ -396,10 +396,10 @@ class ColumnInfoMapperTest {
         }
 
 
-        @DisplayName("dataFormatStrategy: AUTO_BY_CELL_TYPE : 지정한 pattern에 따라 적용되거나, celltype이 지정되면 cellType에 따라 적용된다.")
+        @DisplayName("dataFormatMode: AUTO_BY_CELL_TYPE : 지정한 pattern에 따라 적용되거나, celltype이 지정되면 cellType에 따라 적용된다.")
         @Test
-        void strategyAutoByCellType_AndNoneCellType() {
-            @Excel(dataFormatStrategy = DataFormatStrategy.AUTO_BY_CELL_TYPE)
+        void modeAutoByCellType_AndNoneCellType() {
+            @Excel(dataFormatMode = DataFormatMode.AUTO_BY_CELL_TYPE)
             class TestDto {
 
                 //1. cell type is none and format is none -> is none(general)
@@ -464,13 +464,13 @@ class ColumnInfoMapperTest {
             }
         }
 
-        @DisplayName("dataFormatStrategy: AUTO_BY_CELL_TYPE, CellType Auto : 기본으로 cellType에 따라 적용되고 지정하면 지정한 pattern이 적용된다.")
+        @DisplayName("dataFormatMode: AUTO_BY_CELL_TYPE, CellType Auto : 기본으로 cellType에 따라 적용되고 지정하면 지정한 pattern이 적용된다.")
         @Test
-        void strategyAutoByCellType_AndCellTypeisAuto() {
+        void modeAutoByCellType_AndCellTypeisAuto() {
             //givne
             @Excel(
-                dataFormatStrategy = DataFormatStrategy.AUTO_BY_CELL_TYPE,
-                cellTypeStrategy = CellTypeStrategy.AUTO
+                dataFormatMode = DataFormatMode.AUTO_BY_CELL_TYPE,
+                cellTypeMode = CellTypeMode.AUTO
             )
             class TestDto {
 
@@ -542,7 +542,7 @@ class ColumnInfoMapperTest {
         @Test
         void enumFieldType_shouldBeAllowed() {
             // given
-            @Excel(cellTypeStrategy = CellTypeStrategy.AUTO)
+            @Excel(cellTypeMode = CellTypeMode.AUTO)
             class TestDto {
 
                 @ExcelColumn(headerName = "status")
@@ -564,7 +564,7 @@ class ColumnInfoMapperTest {
         @Test
         void primitiveFieldType_shouldBeAllowed() {
             // given
-            @Excel(cellTypeStrategy = CellTypeStrategy.AUTO)
+            @Excel(cellTypeMode = CellTypeMode.AUTO)
             class TestDto {
 
                 @ExcelColumn(headerName = "intValue")

--- a/src/test/java/io/github/hee9841/excel/example/dto/TypeAutoDto.java
+++ b/src/test/java/io/github/hee9841/excel/example/dto/TypeAutoDto.java
@@ -3,15 +3,15 @@ package io.github.hee9841.excel.example.dto;
 import io.github.hee9841.excel.annotation.Excel;
 import io.github.hee9841.excel.annotation.ExcelColumn;
 import io.github.hee9841.excel.core.meta.ColumnDataType;
-import io.github.hee9841.excel.strategy.CellTypeStrategy;
-import io.github.hee9841.excel.strategy.ColumnIndexStrategy;
+import io.github.hee9841.excel.mode.CellTypeMode;
+import io.github.hee9841.excel.mode.ColumnIndexMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 
 @Excel(
-    columnIndexStrategy = ColumnIndexStrategy.USER_DEFINED,
-    cellTypeStrategy = CellTypeStrategy.AUTO
+    columnIndexMode = ColumnIndexMode.USER_DEFINED,
+    cellTypeMode = CellTypeMode.AUTO
 )
 public class TypeAutoDto {
 


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- 패키지명 변경: strategy -> mode                                                                                                                     
- 클래스명 변경:                                                                                                                                      
  - CellTypeStrategy -> CellTypeMode                                                                                                                  
  - ColumnIndexStrategy -> ColumnIndexMode                                                                                                            
  - DataFormatStrategy -> DataFormatMode                                                                                                              
  - SheetStrategy -> SheetMode                                                                                                                        
- 어노테이션 메서드명 변경:                                                                                                                           
  - columnIndexStrategy() -> columnIndexMode()                                                                                                        
  - cellTypeStrategy() -> cellTypeMode()                                                                                                              
  - dataFormatStrategy() -> dataFormatMode()                                                                                                          
- 빌더 메서드명 변경: sheetStrategy() -> sheetMode()                                                                                                  
- 문서 및 주석의 'strategy' 용어를 'mode'로 통일

⚠️ BREAKING CHANGE: 공개 API의 메서드명 및 클래스명 변경
