### PR TITLE
refactor: AbstractExcelExporter와 SXSSFExporter에 type을 와일드 카드에서 제네릭으로 변경

### DIFF
--- a/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporter.java
@@ -135,7 +135,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      * @param type The class of the data type
      * @param data The list of data objects to be exported
      */
-    protected abstract void validate(Class<?> type, List<T> data);
+    protected abstract void validate(Class<T> type, List<T> data);
 
 
     /**
@@ -157,7 +157,7 @@ public abstract class AbstractExcelExporter<T, W extends Workbook> implements Ex
      * @param type The class type of the data to be exported
      * @param data The list of data objects to be exported
      */
-    protected final void initialize(Class<?> type, List<T> data) {
+    protected final void initialize(Class<T> type, List<T> data) {
         try {
             validate(type, data);
 

--- a/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
+++ b/src/main/java/io/github/hee9841/excel/core/exporter/SXSSFExporter.java
@@ -116,7 +116,7 @@ public class SXSSFExporter<T> extends AbstractExcelExporter<T, SXSSFWorkbook> {
      * @throws ExcelException if data size exceeds max rows limit with ONE_SHEET mode
      */
     @Override
-    protected void validate(Class<?> type, List<T> data) {
+    protected void validate(Class<T> type, List<T> data) {
         if (type == null) {
             throw new IllegalArgumentException("Type must not be null.");
         }

--- a/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/AbstractExcelExporterTest.java
@@ -8,6 +8,7 @@ import io.github.hee9841.excel.exception.ExcelException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import org.apache.poi.ss.formula.functions.T;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("AbstractExcelExporter 테스트")
 class AbstractExcelExporterTest {
+
 
     @DisplayName("워크북이 null이면 예외를 발생한다.")
     @Test
@@ -135,27 +137,25 @@ class AbstractExcelExporterTest {
     @Test
     void canBeUsedWithTryWithResources() throws IOException {
         try (TestExporter testExporter = new TestExporter(new XSSFWorkbook());
-             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             testExporter.write(outputStream);
             assertThat(outputStream.toByteArray().length).isGreaterThan(0);
         }
         // 예외 없이 정상 종료
     }
-
-    private static class TestExporter extends AbstractExcelExporter<Object, Workbook> {
+    private static class TestExporter extends AbstractExcelExporter<T, Workbook> {
 
         private TestExporter(Workbook workbook) {
             super(workbook);
         }
 
         @Override
-        protected void validate(Class<?> type, List<Object> data) {
+        protected void validate(Class<T> type, List<T> data) {
         }
 
 
-
         @Override
-        protected void doAddRows(List<Object> data) {
+        protected void doAddRows(List<T> data) {
         }
     }
 }

--- a/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
+++ b/src/test/java/io/github/hee9841/excel/core/exporter/ExcelExporterTest.java
@@ -13,11 +13,26 @@ import java.util.List;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("ExcelExporter interface 테스트")
 class ExcelExporterTest {
+
+    ByteArrayOutputStream os;
+
+    @BeforeEach
+    void setUp() {
+        os = new ByteArrayOutputStream();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        os.close();
+    }
+
 
     @DisplayName("인터페이스 타입으로 addRows 후 write가 정상 동작한다.")
     @Test
@@ -35,26 +50,26 @@ class ExcelExporterTest {
         // when
         exporter.addRows(List.of(new TestDto("gamma", 3)));
 
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            exporter.write(os);
 
-            // then
-            try (Workbook workbook = WorkbookFactory.create(
-                new ByteArrayInputStream(os.toByteArray()))) {
-                Sheet sheet = workbook.getSheetAt(0);
-                assertEquals("name", sheet.getRow(0).getCell(0).getStringCellValue());
-                assertEquals("number", sheet.getRow(0).getCell(1).getStringCellValue());
+        exporter.write(os);
 
-                assertEquals("alpha", sheet.getRow(1).getCell(0).getStringCellValue());
-                assertEquals(1, (int) sheet.getRow(1).getCell(1).getNumericCellValue());
+        // then
+        try (Workbook workbook = WorkbookFactory.create(
+            new ByteArrayInputStream(os.toByteArray()))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            assertEquals("name", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("number", sheet.getRow(0).getCell(1).getStringCellValue());
 
-                assertEquals("beta", sheet.getRow(2).getCell(0).getStringCellValue());
-                assertEquals(2, (int) sheet.getRow(2).getCell(1).getNumericCellValue());
+            assertEquals("alpha", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals(1, (int) sheet.getRow(1).getCell(1).getNumericCellValue());
 
-                assertEquals("gamma", sheet.getRow(3).getCell(0).getStringCellValue());
-                assertEquals(3, (int) sheet.getRow(3).getCell(1).getNumericCellValue());
-            }
+            assertEquals("beta", sheet.getRow(2).getCell(0).getStringCellValue());
+            assertEquals(2, (int) sheet.getRow(2).getCell(1).getNumericCellValue());
+
+            assertEquals("gamma", sheet.getRow(3).getCell(0).getStringCellValue());
+            assertEquals(3, (int) sheet.getRow(3).getCell(1).getNumericCellValue());
         }
+
     }
 
     @Excel(


### PR DESCRIPTION
## 🔗 이슈 연결

<!-- 이슈 번호를 적어주세요. -->
<!-- 예시: close #1 -->

- #


## 💡 반영할 내용 및 변경 사항 요약

<!-- 작업한 내용을 간략하게 적어주세요. -->
<!-- 예시: 유저 정보 조회 API를 새롭게 추가합니다. -->

- AbstractExcelExporter와 SXSSFExporter에 type을 와일드 카드에서 제네릭으로 변경